### PR TITLE
Task01 Даниил Синицын CSC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD 11)
 # OpenMP позволит распараллеливать циклы на все ядра процессора простыми директивами
 find_package(OpenMP)
 if (OpenMP_CXX_FOUND)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -O3 -march=native")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 else()
     message(FATAL_ERROR "OpenMP not found! You need OpenMP for speedup on multicore CPUs!")

--- a/src/phg/sift/sift.cpp
+++ b/src/phg/sift/sift.cpp
@@ -296,7 +296,7 @@ void phg::SIFT::findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussia
                                        DoGs[1].at<float>(j - 1, i - 1) -
                                        DoGs[1].at<float>(j - 1, i + 1) -
                                        DoGs[1].at<float>(j + 1, i - 1);
-                          Hxy /= 2;
+                          Hxy /= 4;
                           double trace = Hxx + Hyy;
                           double determinant = Hxx * Hyy - Hxy * Hxy;
                           if (determinant <= 0)

--- a/src/phg/sift/sift.cpp
+++ b/src/phg/sift/sift.cpp
@@ -24,7 +24,7 @@
 #define INITIAL_IMG_SIGMA           0.75                 // предполагаемая степень размытия изначальной картинки
 #define INPUT_IMG_PRE_BLUR_SIGMA    1.0                  // сглаживание изначальной картинки
    
-#define SUBPIXEL_FITTING_ENABLE      0    // такие тумблеры включающие/выключающие очередное улучшение алгоритма позволяют оценить какой вклад эта фича вносит в качество результата если в рамках уже готового алгоритма попробовать ее включить/выключить
+#define SUBPIXEL_FITTING_ENABLE      1    // такие тумблеры включающие/выключающие очередное улучшение алгоритма позволяют оценить какой вклад эта фича вносит в качество результата если в рамках уже готового алгоритма попробовать ее включить/выключить
 
 #define ORIENTATION_NHISTS           36   // число корзин при определении ориентации ключевой точки через гистограммы
 #define ORIENTATION_WINDOW_R         3    // минимальный радиус окна в рамках которого будет выбрана ориентиация (в пикселях), R=3 => 5x5 окно
@@ -90,8 +90,8 @@ void phg::SIFT::buildPyramids(const cv::Mat &imgOrg, std::vector<cv::Mat> &gauss
             size_t prevLayer = 0;
 
             // если есть два последовательных гауссовых размытия с sigma1 и sigma2, то результат будет с sigma12=sqrt(sigma1^2 + sigma2^2) => sigma2=sqrt(sigma12^2-sigma1^2)
-            double sigmaPrev = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, prevLayer); // sigma1  - сигма до которой дошла картинка на предыдущем слое
-            double sigmaCur  = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, layer);     // sigma12 - сигма до которой мы хотим дойти на текущем слое
+            double sigmaPrev = INITIAL_IMG_SIGMA * pow(k, prevLayer); // sigma1  - сигма до которой дошла картинка на предыдущем слое
+            double sigmaCur  = INITIAL_IMG_SIGMA * pow(k, layer);     // sigma12 - сигма до которой мы хотим дойти на текущем слое
             double sigma = sqrt(sigmaCur*sigmaCur - sigmaPrev*sigmaPrev);                // sigma2  - сигма которую надо добавить чтобы довести sigma1 до sigma12
 
             // TODO: переделайте это добавочное размытие с варианта "размываем предыдущий слой" на вариант "размываем самый первый слой октавы до степени размытия сигмы нашего текущего слоя"
@@ -273,7 +273,7 @@ void phg::SIFT::findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussia
                                    a2 * DoGs[1].at<float>(yi + 1, xi) +
                                    a3 * DoGs[1].at<float>(yi, xi + 1) +
                                    a4 * DoGs[1].at<float>(yi, xi);
-                          dvalue -= contrast;
+                          dvalue -= center;
                         }
 #endif
                         // TODO сделать фильтрацию слабых точек по слабому контрасту

--- a/src/phg/sift/sift.h
+++ b/src/phg/sift/sift.h
@@ -10,7 +10,7 @@ namespace phg {
     class SIFT {
     public:
         // Можете добавить дополнительных параметров со значениями по умолчанию в конструктор если хотите
-        SIFT(double contrast_threshold = 0.5) : contrast_threshold(contrast_threshold) {}
+        SIFT(double contrast_threshold = 1) : contrast_threshold(contrast_threshold) {}
 
         // Сигнатуру этого метода менять нельзя
         void detectAndCompute(const cv::Mat &originalImg, std::vector<cv::KeyPoint> &kps, cv::Mat &desc);

--- a/tests/test_sift.cpp
+++ b/tests/test_sift.cpp
@@ -69,6 +69,7 @@ void evaluateDetection(const cv::Mat &M, double minRecall, cv::Mat img0=cv::Mat(
 
     ASSERT_FALSE(img0.empty()); // проверка что картинка была загружена
     // убедитесь что рабочая папка (Edit Configurations...->Working directory) указывает на корневую папку проекта (и тогда картинка по умолчанию найдется по относительному пути - data/src/test_sift/unicorn.png)
+    // не нашёл таких кнопок в своём vim'е
     
     size_t width = img0.cols;
     size_t height = img0.rows;
@@ -113,12 +114,11 @@ void evaluateDetection(const cv::Mat &M, double minRecall, cv::Mat img0=cv::Mat(
                 detector->compute(img1, kps1, desc1);
             } else if (method == 2) {
                 // TODO remove 'return' and uncomment
-                return;
-//                method_name = "SIFT_MY";
-//                log_prefix = "[SIFT_MY] ";
-//                phg::SIFT mySIFT;
-//                mySIFT.detectAndCompute(img0, kps0, desc0);
-//                mySIFT.detectAndCompute(img1, kps1, desc1);
+                method_name = "SIFT_MY";
+                log_prefix = "[SIFT_MY] ";
+                phg::SIFT mySIFT;
+                mySIFT.detectAndCompute(img0, kps0, desc0);
+                mySIFT.detectAndCompute(img1, kps1, desc1);
             } else {
                 rassert(false, 13532513412); // это не проверка как часть тестирования, это проверка что число итераций в цикле и if-else ветки все еще согласованы и не разошлись
             }
@@ -220,6 +220,15 @@ void evaluateDetection(const cv::Mat &M, double minRecall, cv::Mat img0=cv::Mat(
             if (angle_diff_sum != 0.0) {
                 std::cout << log_prefix << "average angle difference between matched points: " << (angle_diff_sum / n_matched) << " degrees" << std::endl;
                 // TODO почему SIFT менее точно угадывает средний угол отклонения? изменяется ли ситуация если выкрутить параметр ORIENTATION_VOTES_PEAK_RATIO=0.999? почему?
+                // Потоу что мы на находимся в дискретной картинке, у нас разбито на небольшие группы количество ориентаций
+                // + в моей реализации я не вращал градиент, а взял такой же но вокруг повернутой координаты точки
+                //
+                // Я думаю что наоборот станет хуже, если выкрутить на 0, то тогда улучшится угол т.к. мы будем говорить что точке принадлежат все ориентации
+                //
+                // В реальном мире картинки достаточно сильно изменяются, изменяются много маленьких деталей в локальных патчах, поэтому угол имея много `почти пиков`
+                // может спокойно между ними скакать, чем больше мы будет таких пиков брать, тем с большей вероятностью мы взяли тот нужный нам угол
+                // Но тогда возникнут большие проблемы при матчинге.
+                //
             }
             if (desc_dist_sum != 0.0 && desc_rand_dist_sum != 0.0) {
                 std::cout << log_prefix << "average descriptor distance between matched points: " << (desc_dist_sum / n_matched) << " (random distance: " << (desc_rand_dist_sum / n_matched) << ") => differentiability=" << (desc_dist_sum / desc_rand_dist_sum) << std::endl;


### PR DESCRIPTION
1) Почему SIFT менее точно угадывает средний угол отклонения? изменяется ли ситуация если выкрутить параметр ORIENTATION_VOTES_PEAK_RATIO=0.999? почему?
Потоу что мы на находимся в дискретной картинке, у нас разбито на небольшие группы количество ориентаций
 + в моей реализации я не вращал градиент, а взял такой же но вокруг повернутой координаты точки
 Я думаю что наоборот станет хуже. Если выкрутить на 0 и увеличить количество корзин, то тогда улучшится угол т.к. мы будем говорить что точке принадлежат все ориентации
В реальном мире картинки достаточно сильно изменяются, изменяются много маленьких деталей в локальных патчах, поэтому угол имея много `почти пиков` может спокойно между ними скакать, чем больше мы будет таких пиков брать, тем с большей вероятностью мы взяли тот нужный нам угол
 Но тогда возникнут большие проблемы при матчинге.

2) Как надежно замерить во сколько раз распараллеливание через OpenMP ускоряет ваш вариант SIFT? Попробуйте сделать это на вашем компьютере, какое ускорение относительно однопоточной версии оказалось? Сколько у вашего процессора ядер и сколько потоков?

Запустить 100 раз без него и с ним и поделить одно на другое. 4 ядра 8 потоков. Примерно в 2.4 раза медленне без праллельности вышло.

3) Правда ли можно строить каждый слой в Gaussian пирамиде из самого первого слоя этой октавы? Или нужно обязательно делать так как предложено в статье - дополняя размытие предыдущего слоя этой октавы? Совпадают ли пирамиды визуально?

Ну раз было такое TODO, то правда. У нас же есть всё блюрится Гауссом, а последовательные Гауссы соответствуют результату одного, но с большей сигмой и возможно большим радиусом.
Вообще если размер свёртки фиксирован, то разница конечно будет.

4) Какие ожидания от картинок в Gaussian пирамиде можно придумать? Как проверить что работает корректно? С какой другой картинкой предыдущей октавы должна визуально совпадать конкретная картинка конкретной октавы? Как их визуально сравнить, ведь они разного размера?

Ну i картинка c i-2 картиной с прошлой октавы ? Как посмотреть что оно работает -- нужно отнормировать и умножить на 255 обе картинки, верхнюю можно уменьшить и глядеть на них. В каждой новой октаве мы начинаем скакать с изображения, которое в 2 больше имеет начальную сигму, чем первое в предыдущей октаве

5) Почему в октаве Gaussian пирамиды s+3 картинки а не s+2 например?

  Я думаю что тут смысл в том, что наш NMS происходит в 3д, то есть имея S+3 изображений
   мы получаем S+2 DoG картинок, из которых каждые полседовательные 3 выдают нам кандидатов
   откуда у нас S `3д кубиков` т.к. мы `съедаем` по 2 прмоежутка на детекцию экстремума


6) Какие ожидания от картинок в DoG пирамиде можно придумать?

Они должны очень сильно выделять контуры (неравномерные контуры, красивые линни одной толщины оно не выделит), то есть контуры будут сильно ярче остального или наоборот.

7) Почему порог контрастности должен уменьшаться при увеличении числа слоев в октаве?

Если мы при этом меняем сигму, то т.к. картинки становятся более близки друг к другу и нужно более чувствительно удалять точки. 

8) Какая строка ответственна за определение сигмы (или что почти то же самое - радиуса) которая задает окрестность по которой определяется ориентация ключевой точки?
323   ¦ ¦ ¦ ¦ ¦ ¦ ¦ ¦ ¦ ¦ ¦ int oriRadius = (int) (ORIENTATION_WINDOW_R * (1.0 + k * (layer - 1)));
9) За какой строки вашего кода дескриптор инвариантен к повороту картинки?
cv::transform(shiftInVector, shiftInVector, relativeShiftRotation);
поидее из-за этой строчки патч дескриптора должен был стать повернутым и нужно было его повернутого интерполированием собирать, но я так не сделал, я взял просто квадрат вокруг него, нужно было и его чуть сдвинуть.
