### PR TITLE
Task03 Kirill Pilyugin CSClub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build
 cmake-build*
 data/src/test_sfm/saharov/*.JPG
+opencv
+data/debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@ else()
     message(FATAL_ERROR "OpenMP not found! You need OpenMP for speedup on multicore CPUs!")
 endif()
 
+# macOS:
+# -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include"
+# -DOpenMP_CXX_LIB_NAMES="omp"
+# -DOpenMP_omp_LIBRARY=/usr/local/opt/libomp/lib/libomp.dylib
+
 find_package(OpenCV 4.5.1 REQUIRED)
 #      Linux:
 # скачайте Source code (opencv-4.5.1.zip) отсюда - https://github.com/opencv/opencv/releases распакуйте и скомпилируйте:
@@ -94,6 +99,7 @@ set(SOURCES ${SOURCES} src/phg/matching/cl/bruteforce_matcher_cl.h)
 set(LIBRARIES
         libutils
         ${OpenCV_LIBS}
+        ${OpenMP_CXX_LIBRARIES}
         Eigen3::Eigen
         )
 

--- a/src/phg/sfm/ematrix.cpp
+++ b/src/phg/sfm/ematrix.cpp
@@ -18,22 +18,19 @@ namespace {
         copy(Ecv, E);
 
         Eigen::JacobiSVD<Eigen::MatrixXd> svd(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
-        throw std::runtime_error("not implemented yet");
-// TODO
-
+        Eigen::Matrix3d D = Eigen::Matrix3d::Zero(3, 3);
+        D(0, 0) = 1;
+        D(1, 1) = 1;
+        E = svd.matrixU() * D * svd.matrixV().transpose();
         copy(E, Ecv);
     }
-
 }
 
 cv::Matx33d phg::fmatrix2ematrix(const cv::Matx33d &F, const phg::Calibration &calib0, const phg::Calibration &calib1)
 {
-    throw std::runtime_error("not implemented yet");
-//    matrix3d E = TODO;
-//
-//    ensureSpectralProperty(E);
-//
-//    return E;
+    matrix3d E = calib1.K().t() * F * calib0.K();
+    ensureSpectralProperty(E);
+    return E;
 }
 
 namespace {
@@ -59,21 +56,21 @@ namespace {
         return result;
     }
 
-    double getDepth(const vector2d &m0, const vector2d &m1, const phg::Calibration &calib0, const phg::Calibration &calib1, const matrix34d &P0, const matrix34d &P1)
+    double getDepth(const vector2d &m0, const vector2d &m1,
+                    const phg::Calibration &calib0, const phg::Calibration &calib1,
+                    const matrix34d &P0, const matrix34d &P1)
     {
-        throw std::runtime_error("not implemented yet");
-//        vector3d p0 = TODO;
-//        vector3d p1 = TODO;
-//
-//        vector3d ps[2] = {p0, p1};
-//        matrix34d Ps[2] = {P0, P1};
-//
-//        vector4d X = phg::triangulatePoint(Ps, ps, 2);
-//        if (X[3] != 0) {
-//            X /= X[3];
-//        }
-//
-//        return TODO;
+        vector3d p0 = calib0.unproject(m0);
+        vector3d p1 = calib1.unproject(m1);
+
+        vector3d ps[2] = {p0, p1};
+        matrix34d Ps[2] = {P0, P1};
+
+        vector4d X = phg::triangulatePoint(Ps, ps, 2);
+        if (X[3] != 0) {
+            X /= X[3];
+        }
+        return X[2];
     }
 }
 
@@ -84,82 +81,86 @@ namespace {
 // Это дополнительное ограничение позволяет разложить существенную матрицу с точностью до 4 решений, вместо произвольного проективного преобразования (см. Hartley & Zisserman p.258)
 // Обычно мы можем использовать одну общую калибровку, более менее верную для большого количества реальных камер и с ее помощью выполнить
 // первичное разложение существенной матрицы (а из него, взаимное расположение камер) для последующего уточнения методом нелинейной оптимизации
-void phg::decomposeEMatrix(cv::Matx34d &P0, cv::Matx34d &P1, const cv::Matx33d &Ecv, const std::vector<cv::Vec2d> &m0, const std::vector<cv::Vec2d> &m1, const Calibration &calib0, const Calibration &calib1)
+void phg::decomposeEMatrix(cv::Matx34d &P0, cv::Matx34d &P1, const cv::Matx33d &Ecv,
+                           const std::vector<cv::Vec2d> &m0,const std::vector<cv::Vec2d> &m1,
+                           const Calibration &calib0, const Calibration &calib1)
 {
-    throw std::runtime_error("not implemented yet");
-//    if (m0.size() != m1.size()) {
-//        throw std::runtime_error("decomposeEMatrix : m0.size() != m1.size()");
-//    }
-//
-//    using mat = Eigen::MatrixXd;
-//    using vec = Eigen::VectorXd;
-//
-//    mat E;
-//    copy(Ecv, E);
-//
-//    // (см. Hartley & Zisserman p.258)
-//
-//    Eigen::JacobiSVD<mat> svd(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
-//
-//    mat U = svd.matrixU();
-//    vec s = svd.singularValues();
-//    mat V = svd.matrixV();
-//
-//    // U, V must be rotation matrices, not just orthogonal
-//    if (U.determinant() < 0) U = -U;
-//    if (V.determinant() < 0) V = -V;
-//
-//    std::cout << "U:\n" << U << std::endl;
-//    std::cout << "s:\n" << s << std::endl;
-//    std::cout << "V:\n" << V << std::endl;
-//
-//
-//    mat R0 = TODO;
-//    mat R1 = TODO;
-//
-//    std::cout << "R0:\n" << R0 << std::endl;
-//    std::cout << "R1:\n" << R1 << std::endl;
-//
-//    vec t0 = TODO;
-//    vec t1 = TODO;
-//
-//    std::cout << "t0:\n" << t0 << std::endl;
-//
-//    P0 = matrix34d::eye();
-//
-//    // 4 possible solutions
-//    matrix34d P10 = composeP(R0, t0);
-//    matrix34d P11 = composeP(R0, t1);
-//    matrix34d P12 = composeP(R1, t0);
-//    matrix34d P13 = composeP(R1, t1);
-//    matrix34d P1s[4] = {P10, P11, P12, P13};
-//
-//    // need to select best of 4 solutions: 3d points should be in front of cameras (positive depths)
-//    int best_count = 0;
-//    int best_idx = -1;
-//    for (int i = 0; i < 4; ++i) {
-//        int count = 0;
-//        for (int j = 0; j < (int) m0.size(); ++j) {
-//            if (TODO) {
-//                ++count;
-//            }
-//        }
-//        std::cout << "decomposeEMatrix: count: " << count << std::endl;
-//        if (count > best_count) {
-//            best_count = count;
-//            best_idx = i;
-//        }
-//    }
-//
-//    if (best_count == 0) {
-//        throw std::runtime_error("decomposeEMatrix : can't decompose ematrix");
-//    }
-//
-//    P1 = P1s[best_idx];
-//
-//    std::cout << "best idx: " << best_idx << std::endl;
-//    std::cout << "P0: \n" << P0 << std::endl;
-//    std::cout << "P1: \n" << P1 << std::endl;
+    if (m0.size() != m1.size()) {
+        throw std::runtime_error("decomposeEMatrix : m0.size() != m1.size()");
+    }
+
+    using mat = Eigen::MatrixXd;
+    using vec = Eigen::VectorXd;
+
+    mat E;
+    copy(Ecv, E);
+
+    // (см. Hartley & Zisserman p.258)
+    Eigen::JacobiSVD<mat> svd(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
+
+    mat U = svd.matrixU();
+    vec s = svd.singularValues();
+    mat V = svd.matrixV();
+
+    // U, V must be rotation matrices, not just orthogonal
+    if (U.determinant() < 0) U = -U;
+    if (V.determinant() < 0) V = -V;
+
+    std::cout << "U:\n" << U << std::endl;
+    std::cout << "s:\n" << s << std::endl;
+    std::cout << "V:\n" << V << std::endl;
+
+    mat W(3, 3);
+    W << 0, -1, 0,
+         1, 0, 0,
+         0, 0, 1;
+
+    mat R0 = U * W * V.transpose();
+    mat R1 = U * W.transpose() * V.transpose();
+
+    std::cout << "R0:\n" << R0 << std::endl;
+    std::cout << "R1:\n" << R1 << std::endl;
+
+    vec t0 = U.col(2);
+    vec t1 = -t0;
+
+    std::cout << "t0:\n" << t0 << std::endl;
+
+    P0 = matrix34d::eye();
+
+    // 4 possible solutions
+    matrix34d P10 = composeP(R0, t0);
+    matrix34d P11 = composeP(R0, t1);
+    matrix34d P12 = composeP(R1, t0);
+    matrix34d P13 = composeP(R1, t1);
+    matrix34d P1s[4] = {P10, P11, P12, P13};
+
+    // need to select best of 4 solutions: 3d points should be in front of cameras (positive depths)
+    int best_count = 0;
+    int best_idx = -1;
+    for (int i = 0; i < 4; ++i) {
+        int count = 0;
+        for (int j = 0; j < (int) m0.size(); ++j) {
+            if (getDepth(m0[j], m1[j], calib0, calib1, P0, P1s[i]) > 0) {
+                ++count;
+            }
+        }
+        std::cout << "decomposeEMatrix: count: " << count << std::endl;
+        if (count > best_count) {
+            best_count = count;
+            best_idx = i;
+        }
+    }
+
+    if (best_count == 0) {
+        throw std::runtime_error("decomposeEMatrix : can't decompose ematrix");
+    }
+
+    P1 = P1s[best_idx];
+
+    std::cout << "best idx: " << best_idx << std::endl;
+    std::cout << "P0: \n" << P0 << std::endl;
+    std::cout << "P1: \n" << P1 << std::endl;
 }
 
 void phg::decomposeUndistortedPMatrix(cv::Matx33d &R, cv::Vec3d &O, const cv::Matx34d &P)

--- a/src/phg/sfm/ematrix.cpp
+++ b/src/phg/sfm/ematrix.cpp
@@ -56,10 +56,9 @@ namespace {
         return result;
     }
 
-    double getDepth(const vector2d &m0, const vector2d &m1,
-                    const phg::Calibration &calib0, const phg::Calibration &calib1,
-                    const matrix34d &P0, const matrix34d &P1)
-    {
+    bool depthTest(const vector2d &m0, const vector2d &m1,
+                   const phg::Calibration &calib0, const phg::Calibration &calib1,
+                   const matrix34d &P0, const matrix34d &P1) {
         vector3d p0 = calib0.unproject(m0);
         vector3d p1 = calib1.unproject(m1);
 
@@ -70,7 +69,9 @@ namespace {
         if (X[3] != 0) {
             X /= X[3];
         }
-        return X[2];
+        vector3d x0 = P0 * X;
+        vector3d x1 = P1 * X;
+        return x0[2] > 0 && x1[2] > 0;
     }
 }
 
@@ -141,7 +142,7 @@ void phg::decomposeEMatrix(cv::Matx34d &P0, cv::Matx34d &P1, const cv::Matx33d &
     for (int i = 0; i < 4; ++i) {
         int count = 0;
         for (int j = 0; j < (int) m0.size(); ++j) {
-            if (getDepth(m0[j], m1[j], calib0, calib1, P0, P1s[i]) > 0) {
+            if (depthTest(m0[j], m1[j], calib0, calib1, P0, P1s[i])) {
                 ++count;
             }
         }

--- a/src/phg/sfm/ematrix.h
+++ b/src/phg/sfm/ematrix.h
@@ -7,9 +7,11 @@ namespace phg {
 
     cv::Matx33d fmatrix2ematrix(const cv::Matx33d &F, const Calibration &calib0, const Calibration &calib1);
 
-    void decomposeEMatrix(cv::Matx34d &P0, cv::Matx34d &P1, const cv::Matx33d &E, const std::vector<cv::Vec2d> &m0, const std::vector<cv::Vec2d> &m1, const Calibration &calib0, const Calibration &calib1);
+    void decomposeEMatrix(cv::Matx34d &P0, cv::Matx34d &P1, const cv::Matx33d &E, const std::vector<cv::Vec2d> &m0,
+                          const std::vector<cv::Vec2d> &m1, const Calibration &calib0, const Calibration &calib1);
 
     void decomposeUndistortedPMatrix(cv::Matx33d &R, cv::Vec3d &O, const cv::Matx34d &P);
+
     cv::Matx34d composeCameraMatrixRO(const cv::Matx33d &R, const cv::Vec3d &O);
 
     cv::Matx33d composeEMatrixRT(const cv::Matx33d &R, const cv::Vec3d &T);

--- a/src/phg/sfm/resection.cpp
+++ b/src/phg/sfm/resection.cpp
@@ -49,100 +49,99 @@ namespace {
     // (см. Hartley & Zisserman p.178)
     cv::Matx34d estimateCameraMatrixDLT(const cv::Vec3d *Xs, const cv::Vec3d *xs, int count)
     {
-        throw std::runtime_error("not implemented yet");
-//        using mat = Eigen::MatrixXd;
-//        using vec = Eigen::VectorXd;
-//
-//        mat A(TODO);
-//
-//        for (int i = 0; i < count; ++i) {
-//
-//            double x = xs[i][0];
-//            double y = xs[i][1];
-//            double w = xs[i][2];
-//
-//            double X = Xs[i][0];
-//            double Y = Xs[i][1];
-//            double Z = Xs[i][2];
-//            double W = 1.0;
-//
-//            TODO
-//        }
-//
-//        matrix34d result;
-//          TODO
-//
-//        return canonicalizeP(result);
-    }
+        using mat = Eigen::MatrixXd;
+        using vec = Eigen::VectorXd;
 
+        int a_rows = 2 * count;
+        int a_cols = 12;
+        mat A(a_rows, a_cols);
+        Eigen::RowVector4d zero4 = vec::Zero(4);
+
+        for (int i = 0; i < count; ++i) {
+            double x = xs[i][0];
+            double y = xs[i][1];
+            double w = xs[i][2];
+
+            Eigen::RowVector4d X(Xs[i][0], Xs[i][1], Xs[i][2], 1.0);
+            A.row(2 * i) << zero4, -w * X, y * X;
+            A.row(2 * i + 1) << w * X, zero4, -x * X;
+        }
+
+        Eigen::JacobiSVD<mat> svda(A, Eigen::ComputeFullV);
+        vec null_space = svda.matrixV().col(a_cols - 1);
+        matrix34d result;
+        for (int i = 0; i < 12; ++i) {
+            result(i / 4, i % 4) = null_space[i];
+        }
+        return canonicalizeP(result);
+    }
 
     // По трехмерным точкам и их проекциям на изображении определяем положение камеры
-    cv::Matx34d estimateCameraMatrixRANSAC(const phg::Calibration &calib, const std::vector<cv::Vec3d> &X, const std::vector<cv::Vec2d> &x)
+    cv::Matx34d estimateCameraMatrixRANSAC(const phg::Calibration &calib,
+                                           const std::vector<cv::Vec3d> &X, const std::vector<cv::Vec2d> &x)
     {
-        throw std::runtime_error("not implemented yet");
-//        if (X.size() != x.size()) {
-//            throw std::runtime_error("estimateCameraMatrixRANSAC: X.size() != x.size()");
-//        }
-//
-//        const int n_points = X.size();
-//
-//        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
-//        // будет отличаться от случая с гомографией
-//        const int n_trials = TODO;
-//
-//        const double threshold_px = 3;
-//
-//        const int n_samples = TODO;
-//        uint64_t seed = 1;
-//
-//        int best_support = 0;
-//        cv::Matx34d best_P;
-//
-//        std::vector<int> sample;
-//        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
-//            phg::randomSample(sample, n_points, n_samples, &seed);
-//
-//            cv::Vec3d ms0[n_samples];
-//            cv::Vec3d ms1[n_samples];
-//            for (int i = 0; i < n_samples; ++i) {
-//                ms0[i] = TODO;
-//                ms1[i] = TODO;
-//            }
-//
-//            cv::Matx34d P = estimateCameraMatrixDLT(ms0, ms1, n_samples);
-//
-//            int support = 0;
-//            for (int i = 0; i < n_points; ++i) {
-//                cv::Vec2d px = TODO спроецировать 3Д точку в пиксель с использованием P и calib;
-//                if (cv::norm(px - x[i]) < threshold_px) {
-//                    ++support;
-//                }
-//            }
-//
-//            if (support > best_support) {
-//                best_support = support;
-//                best_P = P;
-//
-//                std::cout << "estimateCameraMatrixRANSAC : support: " << best_support << "/" << n_points << std::endl;
-//
-//                if (best_support == n_points) {
-//                    break;
-//                }
-//            }
-//        }
-//
-//        std::cout << "estimateCameraMatrixRANSAC : best support: " << best_support << "/" << n_points << std::endl;
-//
-//        if (best_support == 0) {
-//            throw std::runtime_error("estimateCameraMatrixRANSAC : failed to estimate camera matrix");
-//        }
-//
-//        return best_P;
-    }
+        if (X.size() != x.size()) {
+            throw std::runtime_error("estimateCameraMatrixRANSAC: X.size() != x.size()");
+        }
 
+        const int n_points = X.size();
+
+        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
+        // будет отличаться от случая с гомографией
+        const int n_samples = 6;
+        const int n_trials = 5000;
+        const double threshold_px = 3;
+        uint64_t seed = 1;
+
+        int best_support = 0;
+        cv::Matx34d best_P;
+
+        std::vector<int> sample;
+        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
+            phg::randomSample(sample, n_points, n_samples, &seed);
+
+            cv::Vec3d Xs[n_samples];
+            cv::Vec3d xs[n_samples];
+            for (int i = 0; i < n_samples; ++i) {
+                Xs[i] = X[sample[i]];
+                xs[i] = calib.unproject(x[sample[i]]);
+            }
+            cv::Matx34d P = estimateCameraMatrixDLT(Xs, xs, n_samples);
+
+            int support = 0;
+            for (int i = 0; i < n_points; ++i) {
+                cv::Vec4d X4(X[i][0], X[i][1], X[i][2], 1);
+                cv::Vec3d proj = calib.project(P * X4);
+                if (proj[2] == 0) {
+                    throw std::runtime_error("infinite point");
+                }
+                cv::Vec2d px = cv::Vec2d(proj[0] / proj[2], proj[1] / proj[2]);
+                if (cv::norm(px - x[i]) < threshold_px) {
+                    ++support;
+                }
+            }
+
+            if (support > best_support) {
+                best_support = support;
+                best_P = P;
+
+                std::cout << "estimateCameraMatrixRANSAC : support: " << best_support << "/" << n_points << std::endl;
+                if (best_support == n_points) {
+                    break;
+                }
+            }
+        }
+
+        std::cout << "estimateCameraMatrixRANSAC : best support: " << best_support << "/" << n_points << std::endl;
+        if (best_support == 0) {
+            throw std::runtime_error("estimateCameraMatrixRANSAC : failed to estimate camera matrix");
+        }
+        return best_P;
+    }
 
 }
 
-cv::Matx34d phg::findCameraMatrix(const Calibration &calib, const std::vector <cv::Vec3d> &X, const std::vector <cv::Vec2d> &x) {
+cv::Matx34d phg::findCameraMatrix(const Calibration &calib,
+                                  const std::vector <cv::Vec3d> &X, const std::vector <cv::Vec2d> &x) {
     return estimateCameraMatrixRANSAC(calib, X, x);
 }

--- a/src/phg/sfm/resection.cpp
+++ b/src/phg/sfm/resection.cpp
@@ -89,7 +89,7 @@ namespace {
         // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
         // будет отличаться от случая с гомографией
         const int n_samples = 6;
-        const int n_trials = 5000;
+        const int n_trials = 10000;
         const double threshold_px = 3;
         uint64_t seed = 1;
 

--- a/src/phg/sfm/sfm_utils.cpp
+++ b/src/phg/sfm/sfm_utils.cpp
@@ -42,7 +42,7 @@ void phg::randomSample(std::vector<int> &dst, int max_id, int sample_size, uint6
 bool phg::epipolarTest(const cv::Vec2d &pt0, const cv::Vec2d &pt1, const cv::Matx33d &F, double t)
 {
     cv::Vec3d line = F * cv::Vec3d(pt0[0], pt0[1], 1.0);
-    double norm = sqrt(line[0] * line[0] + line[1] * line[1]);
-    double dist = abs(line[0] * pt1[0] + line[1] * pt1[1] + line[2]) / norm;
-    return abs(dist) < t;
+    double norm2 = line[0] * line[0] + line[1] * line[1];
+    double dist = line[0] * pt1[0] + line[1] * pt1[1] + line[2];
+    return dist * dist < t * t * norm2;
 }

--- a/src/phg/sfm/sfm_utils.cpp
+++ b/src/phg/sfm/sfm_utils.cpp
@@ -41,5 +41,8 @@ void phg::randomSample(std::vector<int> &dst, int max_id, int sample_size, uint6
 // проверяет, что расстояние от точки до линии меньше порога
 bool phg::epipolarTest(const cv::Vec2d &pt0, const cv::Vec2d &pt1, const cv::Matx33d &F, double t)
 {
-    throw std::runtime_error("not implemented yet");
+    cv::Vec3d line = F * cv::Vec3d(pt0[0], pt0[1], 1.0);
+    double norm = sqrt(line[0] * line[0] + line[1] * line[1]);
+    double dist = abs(line[0] * pt1[0] + line[1] * pt1[1] + line[2]) / norm;
+    return abs(dist) < t;
 }

--- a/src/phg/sfm/triangulation.cpp
+++ b/src/phg/sfm/triangulation.cpp
@@ -6,11 +6,28 @@
 
 // По положениям камер и ключевых точкам определяем точку в трехмерном пространстве
 // Задача эквивалентна поиску точки пересечения двух (или более) лучей
-// Используем DLT метод, составляем систему уравнений. Система похожа на систему для гомографии, там пары уравнений получались из выражений вида x (cross) Hx = 0, а здесь будет x (cross) PX = 0
+// Используем DLT метод, составляем систему уравнений. Система похожа на систему для гомографии,
+// там пары уравнений получались из выражений вида x (cross) Hx = 0, а здесь будет x (cross) PX = 0
 // (см. Hartley & Zisserman p.312)
 cv::Vec4d phg::triangulatePoint(const cv::Matx34d *Ps, const cv::Vec3d *ms, int count)
 {
-    // составление однородной системы + SVD
-    // без подвохов
-    throw std::runtime_error("not implemented yet");
+    int a_rows = 2 * count;
+    int a_cols = 4;
+
+    Eigen::MatrixXd A(a_rows, a_cols);
+    for (int i = 0; i < count; ++i) {
+        double x = ms[i][0];
+        double y = ms[i][1];
+        double z = ms[i][2];
+        const cv::Matx34d& P = Ps[i];
+
+        for (int j = 0; j < 4; j++) {
+            A(2 * i, j) = x * P(2, j) - z * P(0, j);
+            A(2 * i + 1, j) = y * P(2, j) - z * P(1, j);
+        }
+    }
+    Eigen::JacobiSVD<Eigen::MatrixXd> svda(A, Eigen::ComputeFullV);
+    Eigen::VectorXd null_space = svda.matrixV().col(a_cols - 1);
+    cv::Vec4d X(null_space[0], null_space[1], null_space[2], null_space[3]);
+    return X;
 }

--- a/tests/test_sfm.cpp
+++ b/tests/test_sfm.cpp
@@ -18,7 +18,7 @@
 #include "utils/test_utils.h"
 
 
-#define ENABLE_MY_SFM 0
+#define ENABLE_MY_SFM 1
 
 namespace {
 
@@ -64,9 +64,9 @@ namespace {
         std::cout << "checkEmatrixSpectralProperty: s: " << s.transpose() << std::endl;
 
         double thresh = 1e10;
-
         bool rank2 = s[0] > thresh * s[2] && s[1] > thresh * s[2];
-        bool equal = (s[0] < (1.0 + thresh) * s[1]) && (s[1] < (1.0 + thresh) * s[0]);
+        double eps = 1e-10;
+        bool equal = (s[0] < (1.0 + eps) * s[1]) && (s[1] < (1.0 + eps) * s[0]);
 
         return rank2 && equal;
     }
@@ -634,6 +634,7 @@ TEST (SFM, Resection) {
     double rms1 = matRMS(P1res, P1);
     double rms2 = matRMS(P0, P1);
 
+    std::cout << "RMS(P0Res, P0) = " << rms0 << ", RMS(P1Res, P1) = " << rms1 << ", RMS(P0, P1) = " << rms2 << "\n";
     EXPECT_LT(rms0, 0.005);
     EXPECT_LT(rms1, 0.005);
     EXPECT_LT(rms0, 0.05 * rms2);


### PR DESCRIPTION
1) Мы можем получить облако точек и взаимную ориентацию по двум камерам. Почему для выравнивания трёх камер мы использовали резекцию, а не посчитали E матрицу для второй пары камер и не разложили ее? 
Как реализовать выравнивание если мы все же хотим использовать Е матрицу?

Когда мы раскладываем существенную матрицу и получаем матрицу камеры, мы неявно делаем предположение о масштабе сцены (т.к. реальных размеров предметов на сцене мы не знаем, масштаб можно выбирать произвольный). 
При этом эти предположения о масштабе скорее всего не совпадут для первой и второй пары камер. Используя резекцию, мы берем 3д точки из первой пары и таким образом оптимизируем матрицу третьей камеры для того же масштаба. 
Как вариант, можно попробовать разложить E матрицу три раза: для (1, 2), (2, 3) и (1, 3) пар камер. Потом извлечь из них относительные сдвиги камер и модифицировать матрицу для третьей камеры таким образом (нормировать ее часть отвечающую за сдвиг), чтобы суммарный сдвиг совпадал: Translation(1, 3) = T(1, 2) + T(2, 3)

<details><summary>Travis CI</summary><p>

<pre>
$ ./build/test_sfm
Running main() from /home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 9 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 9 tests from SFM
[ RUN      ] SFM.EpipolarDist
[       OK ] SFM.EpipolarDist (0 ms)
[ RUN      ] SFM.FmatrixSimple
Second getNormalizeTransform 0:
[1, 0, -0;
 0, 1, -0;
 0, 0, 1]
second getNormalizeTransform 1:
[1, 0, -1.110223024625157e-15;
 0, 1, -1.110223024625157e-16;
 0, 0, 1]
estimateFMatrixRANSAC : support: 3/8
estimateFMatrixRANSAC : best support: 3/8
F info:
F:
 0.00143568  0.00315337   -0.271618
-0.00280672  0.00180594    0.213873
 -0.0124552   -0.248955     11.1732
U:
-0.0242924  -0.403074   0.914845
 0.0191196    0.91476   0.403544
  0.999522 -0.0272945  0.0145152
s:
    11.1813
 0.00770683
2.09791e-19
V:
-0.00112132   -0.364119    0.931352
 -0.0222583    0.931131    0.364006
   0.999752   0.0203221  0.00914876
checkFmatrixSpectralProperty: s:     11.1813  0.00770683 2.09791e-19
checkFmatrixSpectralProperty: s:     1.12307    0.112607 3.18992e-19
[       OK ] SFM.FmatrixSimple (265 ms)
[ RUN      ] SFM.EmatrixSimple
EmatrixSimple: calib: 
[500, 0, 180;
 0, 500, 120;
 0, 0, 1]
Second getNormalizeTransform 0:
[1, 0, -0;
 0, 1, -4.440892098500626e-16;
 0, 0, 1]
second getNormalizeTransform 1:
[1, 0, 5.551115123125783e-16;
 0, 1, -0;
 0, 0, 1]
estimateFMatrixRANSAC : support: 5/8
estimateFMatrixRANSAC : best support: 5/8
F info:
F:
-8.41266e-05  0.000138307   -0.0134089
-5.66273e-05   0.00028472   -0.0353606
   0.0294607   -0.0489903      4.77215
U:
-0.00280975 -0.00835182   -0.999961
-0.00740917    0.999938 -0.00833081
   0.999969  0.00738548 -0.00287145
s:
    4.77264
 0.00017962
2.33288e-20
V:
0.00617277   0.900012   0.435821
 -0.010265  -0.435749    0.90001
  0.999928 -0.0100293 0.00654886
checkEmatrixSpectralProperty: s:           1           1 1.03078e-17
[       OK ] SFM.EmatrixSimple (267 ms)
[ RUN      ] SFM.EmatrixDecomposeSimple
EmatrixSimple: calib: 
[500, 0, 180;
 0, 500, 120;
 0, 0, 1]
Second getNormalizeTransform 0:
[1, 0, -0;
 0, 1, -4.440892098500626e-16;
 0, 0, 1]
second getNormalizeTransform 1:
[1, 0, 5.551115123125783e-16;
 0, 1, -0;
 0, 0, 1]
estimateFMatrixRANSAC : support: 5/8
estimateFMatrixRANSAC : best support: 5/8
F info:
F:
-8.41266e-05  0.000138307   -0.0134089
-5.66273e-05   0.00028472   -0.0353606
   0.0294607   -0.0489903      4.77215
U:
-0.00280975 -0.00835182   -0.999961
-0.00740917    0.999938 -0.00833081
   0.999969  0.00738548 -0.00287145
s:
    4.77264
 0.00017962
2.33288e-20
V:
0.00617277   0.900012   0.435821
 -0.010265  -0.435749    0.90001
  0.999928 -0.0100293 0.00654886
U:
  0.842633  -0.439362  -0.311337
  -0.38721  -0.896165   0.216694
 -0.374216 -0.0620415  -0.925264
s:
          1
          1
1.03078e-17
V:
  0.948297  -0.227651  -0.221149
  0.240781   0.969985   0.033976
  0.206777 -0.0854679   0.974648
R0:
  -0.155967   -0.933709   -0.322275
  -0.985902     0.16717 -0.00719942
   0.060597    0.316609   -0.946619
R1:
 0.293671  0.912553 -0.284612
 0.890058 -0.152445  0.429601
 0.348646 -0.379482 -0.856994
t0:
-0.311337
 0.216694
-0.925264
decomposeEMatrix: count: 0
decomposeEMatrix: count: 3
decomposeEMatrix: count: 0
decomposeEMatrix: count: 5
best idx: 3
P0: 
[1, 0, 0, 0;
 0, 1, 0, 0;
 0, 0, 1, 0]
P1: 
[0.2936707753476053, 0.9125533536530931, -0.2846117573875503, 0.3113365054353052;
 0.8900580613767708, -0.1524453692498639, 0.4296010437283624, -0.2166944672000446;
 0.3486461287393884, -0.3794822606272471, -0.8569942186411023, 0.9252637938816271]
E: 
[-12.47404852905929, 3.097865244154612, -2.938375396751716;
 2.263931072195153, 13.35382074465814, 0.04817966205953522;
 4.727525322031887, 2.085049198597332, 1]
E1: 
[-12.4740485290593, 3.097865244154612, -2.938375396751716;
 2.263931072195152, 13.35382074465815, 0.0481796620595344;
 4.727525322031889, 2.085049198597333, 1]
E2: 
[-12.4740485290593, 3.097865244154612, -2.938375396751716;
 2.263931072195152, 13.35382074465815, 0.0481796620595344;
 4.727525322031889, 2.085049198597333, 1]
RMS1: 3.44435e-15
RMS2: 3.44435e-15
RMS3: 0
[       OK ] SFM.EmatrixDecomposeSimple (268 ms)
[ RUN      ] SFM.TriangulationSimple
P1:
[0.7071067811865476, 0, 0.7071067811865475, -1.414213562373095;
 0, 1, 0, 0;
 -0.7071067811865475, 0, 0.7071067811865476, 1.414213562373095]
x2:
[0, 0, 2]
x3:
[-2.22045e-16, 0, 2.82843]
X1:
[-5.55112e-17, 6.25241e-17, 0.894427, 0.447214]
|X - X1| = 9.07642e-16
[       OK ] SFM.TriangulationSimple (1 ms)
[ RUN      ] SFM.FmatrixMatchFiltering
detecting points...
matching points...
filtering matches GMS...
Get total 4728 matches.
filtering matches F...
Second getNormalizeTransform 0:
[1.000000000000006, 0, -1.986497518982169e-13;
 0, 1.000000000000006, -9.081703927313738e-15;
 0, 0, 1]
second getNormalizeTransform 1:
[0.9999999999999992, 0, 5.606666067296986e-14;
 0, 0.9999999999999992, -4.490596133361738e-14;
 0, 0, 1]
estimateFMatrixRANSAC : support: 25/16740
estimateFMatrixRANSAC : support: 46/16740
estimateFMatrixRANSAC : support: 121/16740
estimateFMatrixRANSAC : support: 303/16740
estimateFMatrixRANSAC : support: 482/16740
estimateFMatrixRANSAC : support: 906/16740
estimateFMatrixRANSAC : support: 1180/16740
estimateFMatrixRANSAC : support: 1367/16740
estimateFMatrixRANSAC : support: 1637/16740
estimateFMatrixRANSAC : support: 2353/16740
estimateFMatrixRANSAC : support: 2719/16740
estimateFMatrixRANSAC : best support: 2719/16740
F info:
F:
 5.13595e-07  2.00698e-06   0.00297144
-7.20464e-06  2.42355e-06     -0.05317
  0.00316107    0.0472444      5.18064
U:
0.000573492  -0.0514179   -0.998677
 -0.0102618    0.998624  -0.0514211
   0.999947   0.0102777 4.50624e-05
s:
    5.18113
0.000488556
6.31379e-22
V:
 0.000610094    0.0517186     0.998662
  0.00911807      0.99862    -0.051722
    0.999958  -0.00913742 -0.000137678
Second getNormalizeTransform 0:
[0.9999999999999997, 0, 6.76879120529503e-15;
 0, 0.9999999999999997, -1.980141938742614e-14;
 0, 0, 1]
second getNormalizeTransform 1:
[0.9999999999999996, 0, -1.947680595484538e-15;
 0, 0.9999999999999996, -3.24312864587626e-14;
 0, 0, 1]
estimateFMatrixRANSAC : support: 1588/4728
estimateFMatrixRANSAC : support: 2399/4728
estimateFMatrixRANSAC : support: 3230/4728
estimateFMatrixRANSAC : support: 3749/4728
estimateFMatrixRANSAC : support: 4073/4728
estimateFMatrixRANSAC : support: 4110/4728
estimateFMatrixRANSAC : support: 4131/4728
estimateFMatrixRANSAC : support: 4151/4728
estimateFMatrixRANSAC : support: 4152/4728
estimateFMatrixRANSAC : best support: 4152/4728
F info:
F:
 1.51881e-07 -4.76065e-06   0.00811553
-6.01499e-06  7.67242e-08    -0.120924
  0.00641539     0.129096     -8.44136
U:
 0.000961086    0.0643997    -0.997924
  -0.0143204    -0.997821   -0.0644069
   -0.999897    0.0143526 -3.67619e-05
s:
    8.44322
 0.00185529
4.00576e-22
V:
-0.000759739    0.0528698     0.998601
  -0.0152884     0.998484   -0.0528753
    0.999883    0.0153072 -4.97057e-05
n matches gms: 4728
n matches F: 2734
n matches gms + F: 4152
[       OK ] SFM.FmatrixMatchFiltering (10309 ms)
[ RUN      ] SFM.RelativePosition2View
detecting points...
matching points...
filtering matches GMS...
Get total 4738 matches.
Second getNormalizeTransform 0:
[0.9999999999999996, 0, 2.123529999654499e-15;
 0, 0.9999999999999996, -3.455235253675116e-15;
 0, 0, 1]
second getNormalizeTransform 1:
[0.9999999999999992, 0, -6.740708080824179e-14;
 0, 0.9999999999999992, 3.050924739616603e-14;
 0, 0, 1]
estimateFMatrixRANSAC : support: 90/4738
estimateFMatrixRANSAC : support: 285/4738
estimateFMatrixRANSAC : support: 2128/4738
estimateFMatrixRANSAC : support: 3104/4738
estimateFMatrixRANSAC : support: 3939/4738
estimateFMatrixRANSAC : support: 4018/4738
estimateFMatrixRANSAC : support: 4043/4738
estimateFMatrixRANSAC : support: 4069/4738
estimateFMatrixRANSAC : support: 4072/4738
estimateFMatrixRANSAC : support: 4073/4738
estimateFMatrixRANSAC : support: 4074/4738
estimateFMatrixRANSAC : best support: 4074/4738
F info:
F:
 1.53917e-07 -5.10684e-06   0.00857897
-6.11354e-06  5.03396e-08    -0.127316
  0.00645134     0.135924     -8.76432
U:
 0.000978521    0.0646553    -0.997907
  -0.0145216    -0.997802   -0.0646627
   -0.999894    0.0145545 -3.74687e-05
s:
     8.7663
  0.0019807
1.04427e-22
V:
-0.000735837    0.0504905     0.998724
  -0.0155037     0.998604   -0.0504958
     0.99988     0.015521 -4.79772e-05
U:
 -0.025772   0.115946  -0.992921
  0.999605  0.0141567 -0.0242923
 0.0112399  -0.993155  -0.116265
s:
          1
          1
8.32874e-18
V:
   -0.139428 -0.000531905    -0.990232
   0.0167091    -0.999859  -0.00181563
   -0.990091   -0.0167991     0.139418
R0:
    0.967042   -0.0220282    -0.253661
   0.0226129     0.999744 -0.000610789
    0.253609  -0.00514534     0.967293
R1:
   0.999402   0.0256337  -0.0232005
  0.0254972   -0.999656 -0.00616276
 -0.0233505  0.00556753   -0.999712
t0:
 -0.992921
-0.0242923
 -0.116265
decomposeEMatrix: count: 1
decomposeEMatrix: count: 4737
decomposeEMatrix: count: 0
decomposeEMatrix: count: 0
best idx: 1
P0: 
[1, 0, 0, 0;
 0, 1, 0, 0;
 0, 0, 1, 0]
P1: 
[0.967042388535361, -0.02202818408896609, -0.2536607535303121, 0.9929211037564257;
 0.02261288050454232, 0.9997441095458054, -0.0006107894500856849, 0.02429232141480513;
 0.253609298747326, -0.00514534101957006, 0.9672930523138696, 0.1162650628323071]
Camera positions: 
R0:
[1, 0, 0;
 0, 1, 0;
 0, 0, 1]
O0: [0, 0, 0]
R1:
[0.967042388535361, -0.02202818408896609, -0.2536607535303121;
 0.02261288050454232, 0.9997441095458054, -0.0006107894500856849;
 0.253609298747326, -0.00514534101957006, 0.9672930523138696]
O1: [-0.9902320162188271, -0.001815632985344945, 0.1394175653641163]
relative_cos_vals: [0.967293, -0.139418, -0.386042]
exporting point cloud...
exporting 4742 points...
[       OK ] SFM.RelativePosition2View (5682 ms)
[ RUN      ] SFM.Resection
detecting points...
matching points...
filtering matches GMS...
Get total 4726 matches.
Second getNormalizeTransform 0:
[1, 0, -5.843108946800791e-14;
 0, 1, -1.954518739924102e-14;
 0, 0, 1]
second getNormalizeTransform 1:
[1, 0, -3.322681857870972e-14;
 0, 1, -1.355533919935054e-14;
 0, 0, 1]
estimateFMatrixRANSAC : support: 2061/4726
estimateFMatrixRANSAC : support: 4027/4726
estimateFMatrixRANSAC : support: 4064/4726
estimateFMatrixRANSAC : support: 4075/4726
estimateFMatrixRANSAC : support: 4113/4726
estimateFMatrixRANSAC : support: 4124/4726
estimateFMatrixRANSAC : support: 4135/4726
estimateFMatrixRANSAC : support: 4136/4726
estimateFMatrixRANSAC : support: 4140/4726
estimateFMatrixRANSAC : best support: 4140/4726
F info:
F:
 1.28249e-07 -5.30592e-06   0.00857383
-5.64421e-06  9.10042e-08    -0.123726
  0.00616004     0.132017     -8.50789
U:
 0.00100741    0.066382    0.997794
 -0.0145374   -0.997688   0.0663897
  -0.999894   0.0145722 4.00568e-05
s:
    8.50982
 0.00192593
3.46669e-20
V:
-0.000723787    0.0495371     0.998772
  -0.0155118     0.998652   -0.0495424
    0.999879    0.0155286 -4.55992e-05
U:
-0.0669009   0.107449   0.991957
 -0.738459  -0.673899   0.023193
  0.670971  -0.730968   0.124432
s:
          1
          1
9.31364e-18
V:
 0.0982485  0.0894148   0.991137
  0.671741  -0.740786 0.00024195
  0.734242   0.665763  -0.132845
R0:
   0.999704   0.0228588 -0.00834214
  0.0228071    -0.99972 -0.00624733
-0.00848262  0.00605522   -0.999946
R1:
   0.966627  -0.0223788    -0.25521
  0.0231678    0.999732  8.5201e-05
    0.25514 -0.00599501    0.966886
t0:
0.991957
0.023193
0.124432
decomposeEMatrix: count: 0
decomposeEMatrix: count: 0
decomposeEMatrix: count: 4725
decomposeEMatrix: count: 1
best idx: 2
P0: 
[1, 0, 0, 0;
 0, 1, 0, 0;
 0, 0, 1, 0]
P1: 
[0.9666265330461776, -0.02237883578407255, -0.2552103707141941, 0.9919570956006584;
 0.02316776174654917, 0.9997315877556531, 8.52010242058973e-05, 0.02319298841680975;
 0.2551399624260808, -0.005995010634595226, 0.9668855461846084, 0.1244315304728034]
Camera positions: 
R0:
[1, 0, 0;
 0, 1, 0;
 0, 0, 1]
O0: [0, 0, 0]
R1:
[0.9666265330461776, -0.02237883578407255, -0.2552103707141941;
 0.02316776174654917, 0.9997315877556531, 8.52010242058973e-05;
 0.2551399624260808, -0.005995010634595226, 0.9668855461846084]
O1: [-0.9911368338903022, -0.0002419498389795762, 0.1328447137306685]
estimateCameraMatrixRANSAC : support: 11/4726
estimateCameraMatrixRANSAC : support: 404/4726
estimateCameraMatrixRANSAC : support: 1874/4726
estimateCameraMatrixRANSAC : support: 2854/4726
estimateCameraMatrixRANSAC : support: 4162/4726
estimateCameraMatrixRANSAC : support: 4172/4726
estimateCameraMatrixRANSAC : best support: 4172/4726
estimateCameraMatrixRANSAC : support: 20/4726
estimateCameraMatrixRANSAC : support: 32/4726
estimateCameraMatrixRANSAC : support: 66/4726
estimateCameraMatrixRANSAC : support: 4102/4726
estimateCameraMatrixRANSAC : support: 4159/4726
estimateCameraMatrixRANSAC : support: 4162/4726
estimateCameraMatrixRANSAC : support: 4169/4726
estimateCameraMatrixRANSAC : support: 4170/4726
estimateCameraMatrixRANSAC : best support: 4170/4726
RMS(P0Res, P0) = 0.000297507, RMS(P1Res, P1) = 0.0015795, RMS(P0, P1) = 0.307342
[       OK ] SFM.Resection (10141 ms)
[ RUN      ] SFM.ReconstructNViews
detecting points...
matching points...
flann matching...
filtering matches GMS...
Get total 4716 matches.
flann matching...
filtering matches GMS...
Get total 2100 matches.
flann matching...
filtering matches GMS...
Get total 4496 matches.
flann matching...
filtering matches GMS...
Get total 4839 matches.
flann matching...
filtering matches GMS...
Get total 2363 matches.
flann matching...
filtering matches GMS...
Get total 5044 matches.
Second getNormalizeTransform 0:
[1.000000000000001, 0, 2.190086769934017e-14;
 0, 1.000000000000001, 1.065512770842967e-14;
 0, 0, 1]
second getNormalizeTransform 1:
[1.000000000000001, 0, -5.787397702717769e-14;
 0, 1.000000000000001, 4.851458034663963e-15;
 0, 0, 1]
estimateFMatrixRANSAC : support: 544/4716
estimateFMatrixRANSAC : support: 4119/4716
estimateFMatrixRANSAC : support: 4137/4716
estimateFMatrixRANSAC : support: 4146/4716
estimateFMatrixRANSAC : support: 4151/4716
estimateFMatrixRANSAC : best support: 4151/4716
F info:
F:
 1.20296e-07 -4.82422e-06   0.00784303
-5.58192e-06  1.38623e-07    -0.120316
  0.00610837     0.128124     -8.02253
U:
0.000977276   0.0625504    0.998041
 -0.0149917   -0.997929   0.0625581
  -0.999887   0.0150235 3.75115e-05
s:
    8.02446
 0.00192713
1.34315e-20
V:
-0.000761122    0.0505139     0.998723
  -0.0159648     0.998595   -0.0505196
    0.999872    0.0159829 -4.63928e-05
U:
  0.115933 -0.0243727   0.992958
 0.0209346   0.999537    0.02209
 -0.993036  0.0182262    0.11639
s:
          1
          1
1.52687e-18
V:
 0.00321525    0.135009    0.990839
   0.999692  -0.0248029 0.000135591
   0.024594    0.990534   -0.135047
R0:
   0.968131  -0.0213551   -0.249531
   0.022275    0.999752 0.000863008
   0.249451 -0.00639382    0.968366
R1:
   0.999592   0.0216244  -0.0186606
  0.0215002   -0.999746 -0.00682938
 -0.0188036  0.00642538   -0.999803
t0:
0.992958
 0.02209
 0.11639
decomposeEMatrix: count: 4715
decomposeEMatrix: count: 1
decomposeEMatrix: count: 0
decomposeEMatrix: count: 0
best idx: 0
P0: 
[1, 0, 0, 0;
 0, 1, 0, 0;
 0, 0, 1, 0]
P1: 
[0.9681312248151525, -0.02135509165178223, -0.2495313439198705, 0.9929579169142184;
 0.02227501003373579, 0.9997515086982736, 0.0008630084144477931, 0.02208996378009664;
 0.2494509079276115, -0.006393818582851814, 0.9683663375076709, 0.1163898996372541]
estimateCameraMatrixRANSAC : support: 2/3808
estimateCameraMatrixRANSAC : support: 116/3808
estimateCameraMatrixRANSAC : support: 407/3808
estimateCameraMatrixRANSAC : support: 1785/3808
estimateCameraMatrixRANSAC : support: 1848/3808
estimateCameraMatrixRANSAC : best support: 1848/3808
relative_cos_vals: [0.968366, -0.135047, -0.37802]
relative_cos_vals: [0.97493, -0.509352, -0.687657]
exporting 8154 points...
[       OK ] SFM.ReconstructNViews (13839 ms)
[----------] 9 tests from SFM (40772 ms total)
[----------] Global test environment tear-down
[==========] 9 tests from 1 test suite ran. (40772 ms total)
[  PASSED  ] 9 tests.
The command "./build/test_sfm" exited with 0.
</pre>

</p></details>