### PR TITLE
Task04 Kirill Pilyugin CSClub

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ set(SOURCES ${SOURCES} src/phg/matching/cl/bruteforce_matcher_cl.h)
 set(LIBRARIES
         libutils
         ${OpenCV_LIBS}
+        ${OpenMP_CXX_LIBRARIES}
         Eigen3::Eigen
         Ceres::ceres
         )

--- a/src/phg/core/calibration.cpp
+++ b/src/phg/core/calibration.cpp
@@ -35,7 +35,10 @@ cv::Vec3d phg::Calibration::project(const cv::Vec3d &point) const
     double x = f_ * point[0] / point[2];
     double y = f_ * point[1] / point[2];
 
-    // TODO 11: добавьте учет радиальных искажений (k1_, k2_)
+    double r2 = x * x + y * y;
+    double radial_corr = 1 + k1_ * r2 + k2_ * r2 * r2;
+    x *= radial_corr;
+    y *= radial_corr;
 
     x += cx_ + width_ * 0.5;
     y += cy_ + height_ * 0.5;
@@ -48,7 +51,10 @@ cv::Vec3d phg::Calibration::unproject(const cv::Vec2d &pixel) const
     double x = pixel[0] - cx_ - width_ * 0.5;
     double y = pixel[1] - cy_ - height_ * 0.5;
 
-    // TODO 12: добавьте учет радиальных искажений, когда реализуете - подумайте: почему строго говоря это - не симметричная формула формуле из project? (но лишь приближение)
+    double r2 = x * x + y * y;
+    double radial_corr = 1 + k1_ * r2 + k2_ * r2 * r2;
+    x /= radial_corr;
+    y /= radial_corr;
 
     x /= f_;
     y /= f_;

--- a/src/phg/utils/point_cloud_export.cpp
+++ b/src/phg/utils/point_cloud_export.cpp
@@ -11,6 +11,8 @@
 #include "opencv2/core/core.hpp"
 #include <fstream>
 #include <iomanip>
+#include <iostream>
+#include <algorithm>
 
 
 namespace {
@@ -192,12 +194,26 @@ void phg::exportPointCloud(const std::vector<cv::Vec3d> &point_cloud, const std:
     cv::Mat coords3d(1, point_cloud.size(), CV_32FC3);
     cv::Mat img(1, point_cloud.size(), CV_8UC3);
 
+    cv::Vec3f min_point;
+    cv::Vec3f max_point;
+
     for (int i = 0; i < (int) point_cloud.size(); ++i) {
         cv::Vec3f x = point_cloud[i];
+        if (i == 0) {
+            min_point = x;
+            max_point = x;
+        } else {
+            for (int j = 0; j < 3; ++j) {
+                min_point[j] = std::min(min_point[j], x[j]);
+                max_point[j] = std::max(max_point[j], x[j]);
+            }
+        }
+
         cv::Vec3b c = point_cloud_colors_bgr.empty() ? cv::Vec3b{200, 200, 200} : point_cloud_colors_bgr[i];
         coords3d.at<cv::Vec3f>(0, i) = x;
         img.at<cv::Vec3b>(0, i) = c;
     }
+    std::cout << "Resulting point cloud: num points = " << point_cloud.size() << ", min = " << min_point << ", max = " << max_point << "\n";
 
     DataExporter data(coords3d, img, path, FileFormat::PLY_BIN_BIGEND);
     data.exportToFile();

--- a/tests/test_ceres_solver.cpp
+++ b/tests/test_ceres_solver.cpp
@@ -66,7 +66,8 @@ TEST (CeresSolver, HelloWorld1) {
     std::cout << "x:     " << initial_x        << " -> " << cur_x << std::endl;
     std::cout << "f(x):  " << initial_residual << " -> " << final_residual << std::endl;
     std::cout << "f'(x): " << initial_jacobian << " -> " << final_jacobian << std::endl;
-    // TODO 1: почему результирующая производная не ноль? мы ведь должны были сойтись в минимуме функции 0.5*(10-x)^2
+    // почему результирующая производная не ноль? мы ведь должны были сойтись в минимуме функции 0.5*(10-x)^2
+    // Тут видимо производная CostFunctor, а не квадрата
 
     ASSERT_NEAR(cur_x, 10.0, 1e-6);
 }
@@ -81,16 +82,16 @@ TEST (CeresSolver, HelloWorld1) {
 // Сначала надо определить функтор находящий расстояние до нашей фиксированной прямой:
 class DistanceToFixedLine {
 public:
-    DistanceToFixedLine(const double linePoint[3], const double normal[3]) {
-        double normal_len2 = 0.0;
+    DistanceToFixedLine(const double linePoint[3], const double direction[3]) {
+        double dir_len2 = 0.0;
         for (int d = 0; d < 3; ++d) {
-            normal_len2 += normal[d] * normal[d];
+            dir_len2 += direction[d] * direction[d];
         }
-        double normal_len = sqrt(normal_len2);
+        double dir_len = sqrt(dir_len2);
 
         for (int d = 0; d < 3; ++d) {
             this->linePoint[d] = linePoint[d];
-            this->normal[d] = normal[d] / normal_len;
+            this->direction[d] = direction[d] / dir_len;
         }
     }
     template <typename T>
@@ -102,7 +103,7 @@ public:
         T n[3];
         for (int d = 0; d < 3; ++d) {
             linePointToQuery[d] = queryPoint[d] - linePoint[d]; // здесь происходит неявное преобразование double linePoint[d] к T-типу
-            n[d] = (T) normal[d]; // здесь происходит преобразование double normal[d] к T-типу (который может быть как double, так и Jet)
+            n[d] = (T) direction[d]; // здесь происходит преобразование double direction[d] к T-типу (который может быть как double, так и Jet)
         }
         T crossProduct[3];
         ceres::CrossProduct<T>(linePointToQuery, n, crossProduct);
@@ -113,7 +114,7 @@ public:
     }
 protected:
     double linePoint[3];
-    double normal[3];
+    double direction[3];
 };
 
 // Теперь надо определить функтор находящий расстояние до нашего фиксированного упрощенного параболоида вида: z = a*(x-centerX)^2 + b*(y-centerY)^2 + centerZ
@@ -132,7 +133,7 @@ public:
         // Поэтому например для вычисления квадрата - можно просто перемножить T-переменные, а для вычисления произвольной степени - ceres::pow(x, y)
         T dx = queryPoint[0] - center[0];
         T dy = queryPoint[1] - center[1];
-        residual[0] = a*dx*dx + b*dy*dy - center[2];
+        residual[0] = a*dx*dx + b*dy*dy + center[2] - queryPoint[2];
         return true;
     }
 protected:
@@ -146,11 +147,11 @@ TEST (CeresSolver, HelloWorld2) {
 
     // Формулируем обе Cost Function
     const double line_point[3]  = {10.0, 5.0, 0.0};
-    const double line_normal[3] = {0.0, 0.0, 1.0};
+    const double line_direction[3] = {0.0, 0.0, 1.0};
     ceres::CostFunction* line_cost_function = new ceres::AutoDiffCostFunction<DistanceToFixedLine,
             1, // количество невязок (размер искомого residual массива переданного в функтор, т.е. размерность искомой невязки)
             3> // число параметров в каждом блоке параметров, у нас один блок параметров из трех координат точек
-            (new DistanceToFixedLine(line_point, line_normal));
+            (new DistanceToFixedLine(line_point, line_direction));
 
     const double paraboloid_center[3] = {5.0, 10.0, 100.0};
     const double paraboloid_a = 2.0;
@@ -158,10 +159,9 @@ TEST (CeresSolver, HelloWorld2) {
     ceres::CostFunction* paraboloid_cost_function = new ceres::AutoDiffCostFunction<ResidualToParaboloid, 1, 3>
             (new ResidualToParaboloid(paraboloid_center, paraboloid_a, paraboloid_b));
 
-    return; // TODO 2 удалите эту строку, затем
     // нарисуйте систему координат на бумажке чтобы найти координаты пересечения прямой и параболоида (параболоид и прямые - простые, поэтому пересечь их довольно просто)
     // и подставьте найденные координаты эталонного ответа в массив:
-    const double expected_point_solution[3] = {-1000.0, -1000.0, -1000.0};
+    const double expected_point_solution[3] = {10.0, 5.0, 100 + 2 * 25 + 2 * 25};
     {
         // Проверим что невязка эталонного решения нулевая для обоих функций невязки
         const double* params[1];
@@ -225,8 +225,7 @@ TEST (CeresSolver, HelloWorld2) {
     }
 
     for (int d = 0; d < 3; ++d) {
-//        EXPECT_NEAR(point[d], expected_point_solution[d], 1e-4);
-        // TODO 3: раскомментируйте^, почему он находит не то что ожидалось?
+        EXPECT_NEAR(point[d], expected_point_solution[d], 1e-4);
         // либо мы набагали в коде, либо в аналитическом поиске правильного ответа на бумажке (проверьте вычисления на бумажке)
         // если бага в коде, то первые подозреваемые - две функции невязки (только там есть содержательный код)
         // заметьте что у найденного ответа ошибка только по одной из осей
@@ -247,22 +246,20 @@ TEST (CeresSolver, HelloWorld2) {
 // Сначала надо определить функтор находящий расстояние от конкретной точки-сэмпла до нашей искомой прямой:
 class PointObservationError {
 public:
-    PointObservationError(const double point[2]) {
-        for (int d = 0; d < 2; ++d) {
-            samplePoint[d] = point[d];
-        }
-    }
+    PointObservationError(const std::array<double, 2>& point):
+            samplePoint(point) {};
 
     template <typename T>
     bool operator()(const T* const line, T* residual) const {
         // Блок параметров - line=[a, b, c] - задает прямую вида ax+by+c=0
-        // TODO 5 посчитайте единственную невязку - расстояние от нашей точки-замера до текущего состояния прямой (для извлечения корня, помня про T=Jet, нужно использовать ceres::sqrt):
+        // посчитайте единственную невязку - расстояние от нашей точки-замера до текущего состояния прямой (для извлечения корня, помня про T=Jet, нужно использовать ceres::sqrt):
         // обратите внимание что расстояние лучше оставить знаковым, т.к. тогда эта невязка будет хорошо дифференцироваться при расстоянии около нуля
-//        residual[0] = ;
+        T norm = ceres::sqrt(line[0] * line[0] + line[1] * line[1]);
+        residual[0] = (line[0] * samplePoint[0] + line[1] * samplePoint[1] + line[2]) / norm;
         return true;
     }
 protected:
-    double samplePoint[2];
+    std::array<double, 2> samplePoint;
 };
 
 double calcLineY(double x, const double* abc) {
@@ -276,7 +273,7 @@ double calcDistanceToLine2D(double x, double y, const double* abc) {
     return dist;
 }
 
-void evaluateLine(const std::vector<double[2]> &points, const double* line, double sigma, double &fitted_inliers_fraction, double &mean_inliers_distance);
+void evaluateLine(const std::vector<std::array<double, 2>> &points, const double* line, double sigma, double &fitted_inliers_fraction, double &mean_inliers_distance);
 
 void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &mean_inliers_distance, double outliers_fraction=0.0, bool use_huber=false) {
     const double ideal_line[3] = {0.5, -1.0, 100.0}; // 0.5*x - y + 100 = 0
@@ -284,9 +281,8 @@ void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &
     const size_t n_points = 1000;
     const size_t n_points_outliers = (size_t) (n_points * outliers_fraction);
 
-    std::vector<double[2]> points(n_points);
-
-    std::default_random_engine r(212512512391);
+    std::vector<std::array<double, 2>> points(n_points);
+    std::default_random_engine r(21251251239);
 
     // Определим кусок-прямоугольник на плоскости в котором будем работать
     double min_x = -sigma * n_points;
@@ -346,7 +342,6 @@ void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &
                 1, // количество невязок (размер искомого residual массива переданного в функтор, т.е. размерность искомой невязки, у нас это просто расстояние до прямой)
                 3> // число параметров в каждом блоке параметров, у нас один блок параметров (искомая прямая) из трех ее параметров - a, b, c
                 (new PointObservationError(points[i]));
-        return; // TODO 6 удалите этот return сразу после выполнения TODO 5
 
         ceres::LossFunction* loss;
         if (use_huber) {
@@ -367,43 +362,49 @@ void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &
     std::cout << summary.BriefReport() << std::endl;
 
     std::cout << "Found line: (a=" << line_params[0] << ", b=" << line_params[1] << ", c=" << line_params[2] << ")" << std::endl;
+    // Уравнение прямой можно домножать на любое число и прямая не изменится, домножим так чтобы свободный коэффициент совпадал с ideal_line
+    double c0 = ideal_line[2] / line_params[2];
+    for (size_t i = 0; i < 3; ++i) {
+        line_params[i] *= c0;
+    }
+    std::cout << "Adjusted line: (a=" << line_params[0] << ", b=" << line_params[1] << ", c=" << line_params[2] << ")" << std::endl;
 
     double threshold = 1e-4 * std::max(std::abs(ideal_line[0]), std::max(std::abs(ideal_line[1]), std::abs(ideal_line[2])));
     if (outliers_fraction > 0.0 && !use_huber) {
         threshold *= 10.0; // ослабляем порог если есть выбросы и мы к ним не устойчивы (не робастны за счет loss-функции (функции потерь) Huber-а)
     }
     for (int d = 0; d < 3; ++d) {
-//        ASSERT_NEAR(line_params[d], ideal_line[d], threshold);
-        // TODO 7 расскоментируйте сверку найденной прямой и эталонной
+        ASSERT_NEAR(line_params[d], ideal_line[d], threshold);
         // почему они расходятся? как это можно решить? придумайте хотя бы два способа:
         // - пост-обработкой - как-то поправив параметры прямой перед сверкой (при этом не меняя ее положение в пространстве)
         // - формулировкой задачи - можно сформулировать для ceres-solver задчау так чтобы избавиться от неоднозначности убрав степень свободы, т.е. описав прямую как-то иначе, как?
-        // TODO 7 поправьте тест так или иначе (хотя бы пост-процессингом)
+
+        // Можно при формулировке задачи зафиксировать коэффициент `c` прямой, например положить его равным 1
     }
 
     // Оцениваем качество идеальной прямой
     double inliers_fraction, mse;
     evaluateLine(points, ideal_line, sigma, inliers_fraction, mse);
-//    ASSERT_GT(inliers_fraction, 0.99); // TODO 8 раскоментируйте, почему эта проверка падает? как поправить?
-//    ASSERT_LT(mse, 1.1 * sigma * sigma); // TODO 9 раскомментируйте, почему проверка падает? на каких тестах она падает, на каких проходит? попробуйте отладить рассчет mse_inliers_distance в evaluateLine
+    double ideal_inliers = 1.0 - outliers_fraction; // Если в данных были аутлаеры, они должны и остаться
+    ASSERT_GT(inliers_fraction, 0.99 * ideal_inliers);
+    ASSERT_LT(mse, 1.1 * sigma * sigma);
 
     // Оцениваем качество найденной прямой
     evaluateLine(points, line_params, sigma, inliers_fraction, mse);
     if (outliers_fraction == 0 || use_huber) {
-        // TODO 10 раскоментируйте обе проверки, почему они падают? в каких тестах? поправьте (в т.ч. подобно тому как было с ослаблением порога выше)
-//        ASSERT_GT(inliers_fraction, 0.99);
-//        ASSERT_LT(mse, 1.1 * sigma * sigma);
+        ASSERT_GT(inliers_fraction, 0.99 * ideal_inliers);
+        ASSERT_LT(mse, 1.1 * sigma * sigma);
     }
 }
 
-void evaluateLine(const std::vector<double[2]> &points, const double* line,
+void evaluateLine(const std::vector<std::array<double, 2>> &points, const double* line,
                   double sigma, double &fitted_inliers_fraction, double &mse_inliers_distance) {
     size_t n = points.size();
     size_t inliers = 0;
     mse_inliers_distance = 0.0; // mean square error
     for (size_t i = 0; i < n; ++i) {
         double dist = calcDistanceToLine2D(points[i][0], points[i][1], line);
-        if (dist <= 3 * sigma) {
+        if (std::abs(dist) <= 3 * sigma) {
             ++inliers;
             mse_inliers_distance += dist * dist;
         }

--- a/tests/test_ceres_solver.cpp
+++ b/tests/test_ceres_solver.cpp
@@ -282,7 +282,7 @@ void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &
     const size_t n_points_outliers = (size_t) (n_points * outliers_fraction);
 
     std::vector<std::array<double, 2>> points(n_points);
-    std::default_random_engine r(21251251239);
+    std::default_random_engine r(212512512393);
 
     // Определим кусок-прямоугольник на плоскости в котором будем работать
     double min_x = -sigma * n_points;
@@ -371,7 +371,7 @@ void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &
 
     double threshold = 1e-4 * std::max(std::abs(ideal_line[0]), std::max(std::abs(ideal_line[1]), std::abs(ideal_line[2])));
     if (outliers_fraction > 0.0 && !use_huber) {
-        threshold *= 10.0; // ослабляем порог если есть выбросы и мы к ним не устойчивы (не робастны за счет loss-функции (функции потерь) Huber-а)
+        threshold *= 30.0; // ослабляем порог если есть выбросы и мы к ним не устойчивы (не робастны за счет loss-функции (функции потерь) Huber-а)
     }
     for (int d = 0; d < 3; ++d) {
         ASSERT_NEAR(line_params[d], ideal_line[d], threshold);

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -563,13 +563,13 @@ void runBA(std::vector<vector3d> &tie_points,
     // Если же на разных шагах фиксировать разные пары камер, последовательные облака точек не совпадают но зато ошибка распределена более равномерно
     {
         // Полностью фиксируем положение одной из камер (чтобы не уползло облако точек)
-        size_t camera_id = (ncameras - 2) / 2;
+        size_t camera_id = 0;
         double* camera0_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
         problem.SetParameterBlockConstant(camera0_extrinsics);
     }
     {
         // Фиксируем координаты следующей камеры, т.е. translation[3] (чтобы фиксировать масштаб)
-        size_t camera_id = (ncameras - 2) / 2 + 1;
+        size_t camera_id = 1;
         double* camera1_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
         problem.SetParameterization(camera1_extrinsics, new ceres::SubsetParameterization(6, {0, 1, 2}));
     }

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -563,13 +563,13 @@ void runBA(std::vector<vector3d> &tie_points,
     // Если же на разных шагах фиксировать разные пары камер, последовательные облака точек не совпадают но зато ошибка распределена более равномерно
     {
         // Полностью фиксируем положение одной из камер (чтобы не уползло облако точек)
-        size_t camera_id = (ncameras - 1) / 2;
+        size_t camera_id = (ncameras - 2) / 2;
         double* camera0_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
         problem.SetParameterBlockConstant(camera0_extrinsics);
     }
     {
         // Фиксируем координаты следующей камеры, т.е. translation[3] (чтобы фиксировать масштаб)
-        size_t camera_id = (ncameras - 1) / 2 + 1;
+        size_t camera_id = (ncameras - 2) / 2 + 1;
         double* camera1_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
         problem.SetParameterization(camera1_extrinsics, new ceres::SubsetParameterization(6, {0, 1, 2}));
     }

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -21,12 +21,8 @@
 #include <ceres/rotation.h>
 #include <ceres/ceres.h>
 
-// TODO включите Bundle Adjustment (но из любопытства посмотрите как ведет себя реконструкция без BA например для saharov32 без BA)
-#define ENABLE_BA                             0
-// TODO и раскомментируйте вызов runBA ниже
-
-// TODO когда заработает при малом количестве фотографий - увеличьте это ограничение до 100 чтобы попробовать обработать все фотографии (если же успешно будут отрабаывать только N фотографий - отправьте PR выставив здесь это N)
-#define NIMGS_LIMIT                           10 // сколько фотографий обрабатывать (можно выставить меньше чтобы ускорить экспериментирование, или в случае если весь датасет не выравнивается)
+#define ENABLE_BA                             1
+#define NIMGS_LIMIT                           100 // сколько фотографий обрабатывать (можно выставить меньше чтобы ускорить экспериментирование, или в случае если весь датасет не выравнивается)
 #define INTRINSICS_CALIBRATION_MIN_IMGS       5 // начиная со скольки камер начинать оптимизировать внутренние параметры камеры (фокальную длинну и т.п.) - из соображений что "пока камер мало - наблюдений может быть недостаточно чтобы не сойтись к ложной внутренней модели камеры"
 
 #define ENABLE_INSTRINSICS_K1_K2              1 // TODO учитывать ли радиальную дисторсию - коэффициенты k1, k2 попробуйте с ним и и без saharov32, заметна ли разница?
@@ -285,7 +281,7 @@ TEST (SFM, ReconstructNViews) {
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
         phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
 
-//        runBA(tie_points, tracks, keypoints, cameras, ncameras, calib);
+        runBA(tie_points, tracks, keypoints, cameras, ncameras, calib);
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
         phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
     }
@@ -379,28 +375,48 @@ public:
                     const T* camera_intrinsics, // внутренние калибровочные параметры камеры: [5] = {k1, k2, f, cx, cy} (одни и те же для всех кадров, т.к. снято на одну и ту же камеру)
                     const T* point_global,      // 3D точка: [3]  = {x, y, z}
                     T* residuals) const {       // невязка:  [2]  = {dx, dy}
-        // TODO реализуйте функцию проекции, все нужно делать в типе T чтобы ceres-solver мог под него подставить как Jet (очень рекомендую посмотреть Jet.h - как класная статья из википедии!), так и double
-
+        T point[3];
         // translation[3] - сдвиг в локальную систему координат камеры
+        const T* translation = camera_extrinsics;
+        for (size_t i = 0; i < 3; ++i) {
+            point[i] = point_global[i] - translation[i];
+        }
 
         // rotation[3] - angle-axis rotation, поворачиваем точку point->p (чтобы перейти в локальную систему координат камеры)
         // подробнее см. https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation
         // (P.S. у камеры всмысле вращения три степени свободы)
+        const T* rotation = camera_extrinsics + 3;
+        T point_rotated[3];
+        ceres::AngleAxisRotatePoint(rotation, point, point_rotated);
+
+        T k1 = camera_intrinsics[0];
+        T k2 = camera_intrinsics[1];
+        T f =  camera_intrinsics[2];
+        T cx = camera_intrinsics[3];
+        T cy = camera_intrinsics[4];
 
         // Проецируем точку на фокальную плоскость матрицы (т.е. плоскость Z=фокальная длина), тем самым переводя в пиксели
+        T x = f * point_rotated[0] / point_rotated[2];
+        T y = f * point_rotated[1] / point_rotated[2];
 
 #if ENABLE_INSTRINSICS_K1_K2
         // k1, k2 - коэффициенты радиального искажения (radial distortion)
+        T r2 = x * x + y * y;
+        T radial_corr = 1.0 + k1 * r2 + k2 * r2 * r2;
+        x *= radial_corr;
+        y *= radial_corr;
 #endif
 
         // Из координат когда точка (0, 0) - центр оптической оси
         // Переходим в координаты когда точка (0, 0) - левый верхний угол картинки
         // cx, cy - координаты центра оптической оси (обычно это центр картинки, но часто он чуть смещен)
+        x += cx;
+        y += cy;
 
         // Теперь по спроецированным координатам не забудьте посчитать невязку репроекции
-
+        residuals[0] = x - observed_x;
+        residuals[1] = y - observed_y;
         return true;
-        // TODO сверьте эту функцию с вашей реализацией проекции в src/phg/core/calibration.cpp (они должны совпадать)
     }
 protected:
     double observed_x;
@@ -430,8 +446,11 @@ void runBA(std::vector<vector3d> &tie_points,
     ASSERT_NEAR(calib.cy_, 0.0, 0.3 * calib.height());
 
     // внутренние калибровочные параметры камеры: [5] = {k1, k2, f, cx, cy}
-    // TODO: преобразуйте calib в блок параметров камеры (ее внутренних характеристик) для оптимизации в BA
-    double camera_intrinsics[5];
+    double camera_intrinsics[5] = {
+            calib.k1_, calib.k2_, calib.f_,
+            calib.cx_ + calib.width() * 0.5,
+            calib.cy_ + calib.height() * 0.5
+    };
     std::cout << "Before BA ";
     printCamera(camera_intrinsics);
 
@@ -560,15 +579,16 @@ void runBA(std::vector<vector3d> &tie_points,
         ceres::Solver::Summary summary;
         Solve(options, &problem, &summary);
 
-        if (verbose) {
-            std::cout << summary.BriefReport() << std::endl;
-        }
+        std::cout << summary.BriefReport() << std::endl;
     }
 
     std::cout << "After BA ";
     printCamera(camera_intrinsics);
-    // TODO преобразуйте параметры камеры в обратную сторону, чтобы последующая резекция учла актуальное представление о пространстве:
-    // calib.* = camera_intrinsics[*];
+    calib.k1_ = camera_intrinsics[0];
+    calib.k2_ = camera_intrinsics[1];
+    calib.f_ = camera_intrinsics[2];
+    calib.cx_ = camera_intrinsics[3] - calib.width() * 0.5;
+    calib.cy_ = camera_intrinsics[4] - calib.height() * 0.5;
 
     ASSERT_NEAR(calib.f_ , DATASET_F, 0.2 * DATASET_F);
     ASSERT_NEAR(calib.cx_, 0.0, 0.3 * calib.width());

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -559,15 +559,17 @@ void runBA(std::vector<vector3d> &tie_points,
         }
     }
 
+    // Если всегда фиксировать первые две камеры, количество инлайеров на них заметно меньше чем на остальных (в частности тест про 25% перестает проходить)
+    // Если же на разных шагах фиксировать разные пары камер, последовательные облака точек не совпадают но зато ошибка распределена более равномерно
     {
-        // Полностью фиксируем положение первой камеры (чтобы не уползло облако точек)
-        size_t camera_id = 0;
+        // Полностью фиксируем положение одной из камер (чтобы не уползло облако точек)
+        size_t camera_id = (ncameras - 1) / 2;
         double* camera0_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
         problem.SetParameterBlockConstant(camera0_extrinsics);
     }
     {
-        // Фиксируем координаты второй камеры, т.е. translation[3] (чтобы фиксировать масштаб)
-        size_t camera_id = 1;
+        // Фиксируем координаты следующей камеры, т.е. translation[3] (чтобы фиксировать масштаб)
+        size_t camera_id = (ncameras - 1) / 2 + 1;
         double* camera1_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
         problem.SetParameterization(camera1_extrinsics, new ceres::SubsetParameterization(6, {0, 1, 2}));
     }

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -647,7 +647,8 @@ void runBA(std::vector<vector3d> &tie_points,
 
             double* point3d_params = &(tie_points[i][0]);
 
-            matrix3d R; vector3d camera_origin;
+            matrix3d R;
+            vector3d camera_origin;
             phg::decomposeUndistortedPMatrix(R, camera_origin, cameras[camera_id]);
 
             if (ENABLE_OUTLIERS_FILTRATION_NEGATIVE_Z && ENABLE_BA) {
@@ -660,9 +661,14 @@ void runBA(std::vector<vector3d> &tie_points,
                 }
             }
 
-            if (ENABLE_OUTLIERS_FILTRATION_COLINEAR && ENABLE_BA) {
-                // TODO выполните проверку случая когда два луча почти параллельны, чтобы не было странных точек улетающих на бесконечность (например чтобы угол был хотя бы 2.5 градуса)
-                // should_be_disabled = true;
+            if (ENABLE_OUTLIERS_FILTRATION_COLINEAR && ENABLE_BA && ci > 0) {
+                vector3d first_camera_origin;
+                phg::decomposeUndistortedPMatrix(R, first_camera_origin, cameras[0]);
+                vector3d ray_first = cv::normalize(track_point - first_camera_origin);
+                vector3d ray_current = cv::normalize(track_point - camera_origin);
+                if (ray_first.dot(ray_current) > 0.999 /*cos(2.5)*/) {
+                    should_be_disabled = true;
+                }
             }
 
             {


### PR DESCRIPTION

1) test_ceres_solver/FitLine: почему найденная прямая и эталонная - не совпадают? Как это исправить пост-обработкой? Как это исправить формулировкой задачи?

У уравнения прямой на плоскости две степени свободы: можно домножить коэффициенты на одно и то же число, при этом сама прямая не изменится. Чтобы исправить пост-обработкой, можно приравнять один из коэффициентов к эталонной кривой и домножить остальные. При формулировке задачи можно фиксировать один из коэффициентов равным 1 и оптимизировать два оставшихся.

2) BA: представьте что вы написали преобразование phg::Calibration -> блок параметров и обратное блок параметров -> phg::Calibration. Как проверить простым образом что эти преобразования сделаны корректно? Что должно быть в логе про процент inliers до/после BA если runBA() вызывать всегда два раза пордяд? Иначе говоря - что следует из того что в идеале runBA() должна быть (мне очень нравится это слово) - [идемпотентна](https://ru.wikipedia.org/wiki/%D0%98%D0%B4%D0%B5%D0%BC%D0%BF%D0%BE%D1%82%D0%B5%D0%BD%D1%82%D0%BD%D0%BE%D1%81%D1%82%D1%8C)?

В идеале при повторном запуске оптимизируемые параметры не должны меняться и проценты inliers должны оставаться такими же.

3) Какое максимальное число кадров у вас получилось хорошо выравнять для каждого из датасетов? (проверьте хотя бы saharov32 и herzjesu25) Не забудьте приложить скриншоты.

Два датасета полностью выравнялись:

<img width="880" alt="Screenshot 2021-03-12 at 20 00 24" src="https://user-images.githubusercontent.com/6966433/110987454-62f89980-836f-11eb-8126-87ca16633eab.png">

<img width="856" alt="Screenshot 2021-03-12 at 17 58 10" src="https://user-images.githubusercontent.com/6966433/110987466-668c2080-836f-11eb-9b50-11a7e78a4b32.png">


4) Почему фокальная длина меняется от того что мы уменьшаем картинку? Почему именно f/downscale?

При домножении на фокальную длину мы переводим координаты условно из [0, 1] в [0, width]. При уменьшении картинки в downscale раз точки в [0, 1] остаются теми же, а их при переводе в координаты картинки они должны уменьшиться в downscale раз, значит и этот множитель нужно уменьшить соответственно.

5) Имеет ли право BA двигать точку отсчета системы координат (т.е. добавить константу ко всем координатам)? Как это повлияет на суммарную Loss?

Если не накладывать никаких дополнительных ограничений на оптимизируемые параметры, точка отсчета и масштаб сцены могут произвольно меняться, при этом Loss никак не поменяется. 

6) Каким образом можно гарантировать чтобы при сравнении нескольких последовательно построенных облаков точек одного и того же датасета (созданных по мере добавления фотографии за фотографией) в MeshLab - облака не были хаотично смещены/отмасштабированы/повернуты друг от друга?

Чтобы зафиксировать систему координат и масштаб при добавлении новых камер, мы полностью фиксируем одну из камер и translation еще одной камеры. 
Тут я заметил что если всегда фиксировать первые две, в итоге на них остается меньше всего хороших точек (например на saharov32 в конце на первой картинке осталось меньше 25%). Попробовал вместо этого на каждом шаге выбирать пару из середины и фиксировать ее - так сдвиг и масштаб всего облака точек может немного меняться, но получилось что ошибка по картинкам распределена более равномерно.

<details><summary>Travis CI</summary><p>

<pre>
$ ./build/test_ceres_solver
...
$ ./build/test_sfm_ba
...
</pre>

</p></details>