### PR TITLE
Task04 Sokolov Michael

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 
 ![MeshLab](/.github/screens/meshlab.png?raw=true)
 
+P.S. если у вас случается ошибка ```unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.``` - вероятнее всего это обычный segfault (например выход за пределы массива), но почему то связка CLion + MSVC/Win это не обрабатывают корректно и не дают возможности увидеть строчку падения даже под отладчиком. Рекомендуется использовать Linux.
+
 Задание 4.4.
 =========
 

--- a/src/phg/core/calibration.cpp
+++ b/src/phg/core/calibration.cpp
@@ -27,14 +27,11 @@ double found_extreme(double init_value, double k1, double k2, double n){
     int max_step = 30000;
     int step = 0;
 
-//    std::cout << "start: " << init_value  << " k1: "<< k1 << " k2: " << k2<< " n: " << n << std::endl;
     do{
         double dyx = (fx - fx1) / (x - x_prev2);
         double dyx2 = (fx1 - fx2) / (x_prev2 - x_prev3);
         double dyxx = (dyx - dyx2) /((x -  x_prev3));
 
-        //        if(std::fabs(fx - fx2) < 1e-6)
-        //            fx2 = fx + 1;
         x_n = x - dyx / dyxx;
 
         if(x_n < 0)
@@ -49,12 +46,6 @@ double found_extreme(double init_value, double k1, double k2, double n){
         step+=1;
     }
     while(std::fabs(fx) > 1);
-
-    //    if(x_n < 0)
-    {
-
-//        std::cout << "finish = " << x_n  << " fx= " << fx<< std::endl;
-    }
 
     return x_n;
 }
@@ -117,15 +108,16 @@ cv::Vec3d phg::Calibration::unproject(const cv::Vec2d &pixel) const
     {
         double R = x * x + y * y;
 
+        /*
+        Я решил искать значение радиуса численными методом. Возможно не всегда он правильно находит, потому что проверка на количество инлайнеров не проходят 
+*/
         double r = newton::found_extreme(std::sqrt(R), k1_,k2_, std::sqrt(R));
         r = std::fabs(r) < 1 ? R : r;
         double dist = 1. + k1_ * r + r * r * k2_;
-//                std::cout << "x = " << x << std::endl;
 
         x = x / dist;
         y = y / dist;
 
-//                std::cout << "x und = " << x << std::endl;
     }
 
     x /= f_;

--- a/src/phg/core/calibration.cpp
+++ b/src/phg/core/calibration.cpp
@@ -1,6 +1,64 @@
 #include <phg/sfm/defines.h>
 #include "calibration.h"
 
+#include "iostream"
+
+namespace newton{
+
+inline double f_x(double x, double k1, double k2, double n){
+    double x2 = x* x;
+    return x * (1 + k1 *x2 + x2*x2* k2) - n;
+}
+double found_extreme(double init_value, double k1, double k2, double n){
+
+    double delta = 0.3;
+    double fx = f_x(init_value, k1,k2, n);
+    double fx1 = f_x(init_value - delta, k1,k2, n);
+    double fx2 = f_x(init_value - 2 * delta, k1,k2, n);
+
+
+
+    double x = init_value;
+    double x_n = 0.;
+
+    double x_prev2 = x - delta;
+    double x_prev3 = x - 3 * delta;
+
+    int max_step = 30000;
+    int step = 0;
+
+//    std::cout << "start: " << init_value  << " k1: "<< k1 << " k2: " << k2<< " n: " << n << std::endl;
+    do{
+        double dyx = (fx - fx1) / (x - x_prev2);
+        double dyx2 = (fx1 - fx2) / (x_prev2 - x_prev3);
+        double dyxx = (dyx - dyx2) /((x -  x_prev3));
+
+        //        if(std::fabs(fx - fx2) < 1e-6)
+        //            fx2 = fx + 1;
+        x_n = x - dyx / dyxx;
+
+        if(x_n < 0)
+            break;
+
+        x_prev3 = x_prev2;
+        x_prev2 = x;
+        x = x_n;
+        fx2 = fx1;
+        fx1 = fx;
+        fx = f_x(x_n, k1,k2,n);
+        step+=1;
+    }
+    while(std::fabs(fx) > 1);
+
+    //    if(x_n < 0)
+    {
+
+//        std::cout << "finish = " << x_n  << " fx= " << fx<< std::endl;
+    }
+
+    return x_n;
+}
+}
 
 phg::Calibration::Calibration(int width, int height)
     : width_(width)
@@ -35,6 +93,12 @@ cv::Vec3d phg::Calibration::project(const cv::Vec3d &point) const
     double x = f_ * point[0] / point[2];
     double y = f_ * point[1] / point[2];
 
+    double r = x * x + y * y;
+    double distortion = 1 + k1_ * r + k2_*r*r;
+
+    x *= distortion;
+    y *= distortion;
+
     // TODO 11: добавьте учет радиальных искажений (k1_, k2_)
 
     x += cx_ + width_ * 0.5;
@@ -49,6 +113,20 @@ cv::Vec3d phg::Calibration::unproject(const cv::Vec2d &pixel) const
     double y = pixel[1] - cy_ - height_ * 0.5;
 
     // TODO 12: добавьте учет радиальных искажений, когда реализуете - подумайте: почему строго говоря это - не симметричная формула формуле из project? (но лишь приближение)
+    if(std::fabs(k1_) > 0)
+    {
+        double R = x * x + y * y;
+
+        double r = newton::found_extreme(std::sqrt(R), k1_,k2_, std::sqrt(R));
+        r = std::fabs(r) < 1 ? R : r;
+        double dist = 1. + k1_ * r + r * r * k2_;
+//                std::cout << "x = " << x << std::endl;
+
+        x = x / dist;
+        y = y / dist;
+
+//                std::cout << "x und = " << x << std::endl;
+    }
 
     x /= f_;
     y /= f_;

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -23,6 +23,7 @@
 
 // TODO включите Bundle Adjustment (но из любопытства посмотрите как ведет себя реконструкция без BA например для saharov32 без BA)
 #define ENABLE_BA                             0
+// TODO и раскомментируйте вызов runBA ниже
 
 // TODO когда заработает при малом количестве фотографий - увеличьте это ограничение до 100 чтобы попробовать обработать все фотографии (если же успешно будут отрабаывать только N фотографий - отправьте PR выставив здесь это N)
 #define NIMGS_LIMIT                           10 // сколько фотографий обрабатывать (можно выставить меньше чтобы ускорить экспериментирование, или в случае если весь датасет не выравнивается)
@@ -284,7 +285,7 @@ TEST (SFM, ReconstructNViews) {
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
         phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
 
-        runBA(tie_points, tracks, keypoints, cameras, ncameras, calib);
+//        runBA(tie_points, tracks, keypoints, cameras, ncameras, calib);
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
         phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
     }
@@ -429,7 +430,8 @@ void runBA(std::vector<vector3d> &tie_points,
     ASSERT_NEAR(calib.cy_, 0.0, 0.3 * calib.height());
 
     // внутренние калибровочные параметры камеры: [5] = {k1, k2, f, cx, cy}
-    double camera_intrinsics[5] = {calib.k1_, calib.k2_, calib.f_, calib.cx_ + 0.5 * calib.width(), calib.cy_ + 0.5 * calib.height()};
+    // TODO: преобразуйте calib в блок параметров камеры (ее внутренних характеристик) для оптимизации в BA
+    double camera_intrinsics[5];
     std::cout << "Before BA ";
     printCamera(camera_intrinsics);
 
@@ -565,12 +567,8 @@ void runBA(std::vector<vector3d> &tie_points,
 
     std::cout << "After BA ";
     printCamera(camera_intrinsics);
-
-    calib.k1_ = camera_intrinsics[0];
-    calib.k2_ = camera_intrinsics[1];
-    calib.f_ = camera_intrinsics[2];
-    calib.cx_ = camera_intrinsics[3] - 0.5 * calib.width();
-    calib.cy_ = camera_intrinsics[4] - 0.5 * calib.height();
+    // TODO преобразуйте параметры камеры в обратную сторону, чтобы последующая резекция учла актуальное представление о пространстве:
+    // calib.* = camera_intrinsics[*];
 
     ASSERT_NEAR(calib.f_ , DATASET_F, 0.2 * DATASET_F);
     ASSERT_NEAR(calib.cx_, 0.0, 0.3 * calib.width());

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -60,14 +60,14 @@
 //#define DATASET_F                    (1520.4 / DATASET_DOWNSCALE) // see temple47/README.txt about K-matrix (i.e. focal length = K11 from templeR_par.txt)
 
 // Специальный датасет прямо с Марса!
-/*
-#define DATASET_DIR                  "perseverance25"
-#define DATASET_DOWNSCALE            1
-#define DATASET_F                    4720.4
-// на этом датасете фотографии длиннофокусные, поэтому многие лучи почти колинеарны, поэтому этот фильтр подавляет все точки и третья камера не подвыравнивается
-#undef  ENABLE_OUTLIERS_FILTRATION_COLINEAR
-#define ENABLE_OUTLIERS_FILTRATION_COLINEAR 0
- */
+
+//#define DATASET_DIR                  "perseverance25"
+//#define DATASET_DOWNSCALE            2
+//#define DATASET_F                    (4720.4 / DATASET_DOWNSCALE)
+//// на этом датасете фотографии длиннофокусные, поэтому многие лучи почти колинеарны, поэтому этот фильтр подавляет все точки и третья камера не подвыравнивается
+//#undef  ENABLE_OUTLIERS_FILTRATION_COLINEAR
+//#define ENABLE_OUTLIERS_FILTRATION_COLINEAR 1
+
 // и в целом все плохо... у меня не получилось выравнять этот датасет нашим простым прототипом
 //________________________________________________________________________________
 
@@ -163,6 +163,9 @@ TEST (SFM, ReconstructNViews) {
 
             imgs.push_back(img);
             imgs_labels.push_back(img_name);
+            std::stringstream ss;
+//            ss << std::string("data/src/datasets/") + DATASET_DIR + "/"<< i << ".png";
+//            cv::imwrite(ss.str(), img);
         }
     }
 
@@ -218,7 +221,8 @@ TEST (SFM, ReconstructNViews) {
                 }
             }
 
-            matches[i][j] = good_matches_gms;
+            if(inliers > 20)
+                matches[i][j] = good_matches_gms;
         }
     }
 


### PR DESCRIPTION
1) test_ceres_solver/FitLine: почему найденная прямая и эталонная - не совпадают? Как это исправить пост-обработкой? Как это исправить формулировкой задачи?

Две прямые не совпадают по направлению прямой. В пост-обработки можно привести уравнение прямой Ax +By + C = 0 к виду y=Ax+C. Тем самым уменьшить количество степеней свободы.

2) BA: представьте что вы написали преобразование phg::Calibration -> блок параметров и обратное блок параметров -> phg::Calibration. Как проверить простым образом что эти преобразования сделаны корректно? Что должно быть в логе про процент inliers до/после BA если runBA() вызывать всегда два раза пордяд? Иначе говоря - что следует из того что в идеале runBA() должна быть (мне очень нравится это слово) - [идемпотентна](https://ru.wikipedia.org/wiki/%D0%98%D0%B4%D0%B5%D0%BC%D0%BF%D0%BE%D1%82%D0%B5%D0%BD%D1%82%D0%BD%D0%BE%D1%81%D1%82%D1%8C)?

Чтобы проверить, что выполнено правильно надо выполнить phg::Calibration -> блок параметров  -> phg::Calibration и должны значение начальное и выходное совпадать. Повторный запуск runBA не должен менять значение. 

3) Какое максимальное число кадров у вас получилось хорошо выравнять для каждого из датасетов? (проверьте хотя бы saharov32 и herzjesu25) Не забудьте приложить скриншоты.

В тестах не проходит ASSERT_GT(ninls, 0.25 * nproj); 

![Screenshot from 2021-03-16 16-26-31](https://user-images.githubusercontent.com/7705520/111344056-170a6500-868d-11eb-9819-276d371f957d.png)

![Screenshot from 2021-03-16 16-26-57](https://user-images.githubusercontent.com/7705520/111344112-25588100-868d-11eb-9cf1-5363178401f8.png)

![Screenshot from 2021-03-16 16-27-18](https://user-images.githubusercontent.com/7705520/111344126-28537180-868d-11eb-9bee-99430bd9079a.png)

Для набора temple47 получилось выровнять камеры, правда без выравнивания внутренних параметров камер и калибровки(взяты были изначальные). Плохо сходилась модель изначально также из за малого количества сматченных точек после фильтрации, я добавил порог в минимум 20 сматченных точек после фильтрации между двумя изображениями.

Для функции Calibration::unproject  я добавил поиск r методом Ньютона. 

Для набора с марса ничего не получилось(( 

4) Если бы вычисления в double были абсолютно точны - можно ли было бы назвать вычисления в Calibration::project/unproject строго зеркальными?

Если брать за основу для функции Calibration::project/unproject формулу r^2 = x^2 + y^2, то преобразования не являются зеркальными. 


5) Почему фокальная длина меняется от того что мы уменьшаем картинку? Почему именно f/downscale?

Если идти от противного, при уменьшении изображения мы не изменим значение фокальной длины, то при выравнивании камер увидем, то угол между соседними камерами будет уменьшаться, может привести не к правильной структуре.
фокусная длина и коррдината пикселя прямопорпорциональны

6) Имеет ли право BA двигать точку отсчета системы координат (т.е. добавить константу ко всем координатам)? Как это повлияет на суммарную Loss?

7) Каким образом можно гарантировать чтобы при сравнении нескольких последовательно построенных облаков точек одного и того же датасета (созданных по мере добавления фотографии за фотографией) в MeshLab - облака не были хаотично смещены/отмасштабированы/повернуты друг от друга?

100) Если есть - фидбек/идеи по улучшению задания.

<details><summary>Travis CI</summary><p>

<pre>
./build/test_ceres_solver

Running main() from /home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/libs/3rdparty/libgtest/googletest/src/gtest_main.cc

[==========] Running 5 tests from 1 test suite.

[----------] Global test environment set-up.

[----------] 5 tests from CeresSolver

[ RUN      ] CeresSolver.HelloWorld1

iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time

   0  1.250000e+01    0.00e+00    5.00e+00   0.00e+00   0.00e+00  1.00e+04        0    1.79e-05    1.54e-04

   1  1.249750e-07    1.25e+01    5.00e-04   5.00e+00   1.00e+00  3.00e+04        1    8.30e-05    9.05e-04

   2  1.388518e-16    1.25e-07    1.67e-08   5.00e-04   1.00e+00  9.00e+04        1    6.91e-06    9.26e-04

Ceres Solver Report: Iterations: 3, Initial cost: 1.250000e+01, Final cost: 1.388518e-16, Termination: CONVERGENCE

x:     5 -> 10

f(x):  5 -> 1.66644e-08

f'(x): -1 -> -1

[       OK ] CeresSolver.HelloWorld1 (2 ms)

[ RUN      ] CeresSolver.HelloWorld2

iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time

   0  6.906250e+04    0.00e+00    1.52e+04   0.00e+00   0.00e+00  1.00e+04        0    8.11e-06    2.81e-05

   1  2.569682e+03    6.65e+04    1.83e+03   1.26e+02   9.63e-01  3.00e+04        1    1.41e-05    6.60e-05

   2  1.651192e+02    2.40e+03    3.68e+02   2.88e+01   9.36e-01  8.87e+04        1    7.15e-06    8.51e-05

   3  1.220700e+01    1.53e+02    8.51e+01   1.29e+01   9.26e-01  2.33e+05        1    5.96e-06    1.03e-04

   4  1.383213e+00    1.08e+01    2.60e+01   8.51e+00   8.87e-01  4.33e+05        1    5.01e-06    1.19e-04

   5  1.156496e-01    1.27e+00    8.07e+00   1.13e+01   9.16e-01  1.03e+06        1    4.05e-06    1.34e-04

   6  1.068210e-02    1.05e-01    2.52e+00   5.72e+00   9.08e-01  2.24e+06        1    5.01e-06    1.50e-04

   7  9.114024e-04    9.77e-03    7.48e-01   3.23e+00   9.15e-01  5.21e+06        1    4.05e-06    1.65e-04

   8  7.165090e-05    8.40e-04    2.11e-01   1.80e+00   9.21e-01  1.30e+07        1    6.20e-06    1.82e-04

   9  5.330001e-06    6.63e-05    5.79e-02   9.76e-01   9.26e-01  3.39e+07        1    5.96e-06    2.06e-04

  10  3.824134e-07    4.95e-06    1.55e-02   5.18e-01   9.28e-01  9.11e+07        1    5.96e-06    2.23e-04

  11  2.681046e-08    3.56e-07    4.11e-03   2.71e-01   9.30e-01  2.50e+08        1    5.96e-06    2.40e-04

  12  1.853666e-09    2.50e-08    1.08e-03   1.40e-01   9.31e-01  6.95e+08        1    5.01e-06    2.56e-04

  13  1.272860e-10    1.73e-09    2.82e-04   7.25e-02   9.31e-01  1.94e+09        1    5.01e-06    2.73e-04

  14  8.734281e-12    1.19e-10    7.35e-05   3.73e-02   9.31e-01  5.43e+09        1    5.96e-06    2.91e-04

  15  6.026440e-13    8.13e-12    1.92e-05   1.92e-02   9.31e-01  1.51e+10        1    5.01e-06    3.08e-04

  16  4.210413e-14    5.61e-13    5.03e-06   9.87e-03   9.30e-01  4.18e+10        1    5.01e-06    3.25e-04

  17  3.004234e-15    3.91e-14    1.33e-06   5.10e-03   9.29e-01  1.14e+11        1    5.01e-06    3.46e-04

  18  2.213010e-16    2.78e-15    3.55e-07   2.64e-03   9.27e-01  3.02e+11        1    5.01e-06    3.63e-04

  19  1.706221e-17    2.04e-16    9.62e-08   1.38e-03   9.25e-01  7.81e+11        1    5.96e-06    3.81e-04

  20  1.400711e-18    1.57e-17    2.67e-08   7.29e-04   9.21e-01  1.94e+12        1    6.20e-06    3.99e-04

  21  1.250439e-19    1.28e-18    7.61e-09   3.90e-04   9.17e-01  4.60e+12        1    5.01e-06    4.16e-04

  22  1.243723e-20    1.13e-19    2.25e-09   2.12e-04   9.11e-01  1.04e+13        1    6.20e-06    4.35e-04

  23  1.414669e-21    1.10e-20    6.95e-10   1.18e-04   9.05e-01  2.22e+13        1    5.01e-06    4.51e-04

  24  1.876081e-22    1.23e-21    2.25e-10   6.73e-05   9.00e-01  4.55e+13        1    5.96e-06    4.69e-04

  25  2.953288e-23    1.58e-22    7.84e-11   3.96e-05   8.94e-01  8.91e+13        1    5.96e-06    4.88e-04

Ceres Solver Report: Iterations: 26, Initial cost: 6.906250e+04, Final cost: 2.953288e-23, Termination: CONVERGENCE

Found intersection point: (10, 5, 200)

[       OK ] CeresSolver.HelloWorld2 (0 ms)

[ RUN      ] CeresSolver.FitLineNoise

iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time

   0  4.506761e+07    0.00e+00    1.61e+08   0.00e+00   0.00e+00  1.00e+04        0    1.17e-04    1.74e-04

   1  4.658321e+02    4.51e+07    1.33e+04   1.00e+02   1.00e+00  3.00e+04        1    2.98e-04    5.03e-04

   2  4.654480e+02    3.84e-01    7.49e-01   1.03e-02   1.00e+00  9.00e+04        1    3.32e-04    8.54e-04

Ceres Solver Report: Iterations: 3, Initial cost: 4.506761e+07, Final cost: 4.654480e+02, Termination: CONVERGENCE

Found line: (a=0.500052, b=-1, c=100.057)

[       OK ] CeresSolver.FitLineNoise (2 ms)

[ RUN      ] CeresSolver.FitLineNoiseAndOutliers

iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time

   0  1.201187e+08    0.00e+00    1.37e+08   0.00e+00   0.00e+00  1.00e+04        0    1.17e-04    1.55e-04

   1  7.448902e+07    4.56e+07    5.33e+07   8.51e+01   1.41e+00  3.00e+04        1    3.14e-04    4.94e-04

   2  6.831236e+07    6.18e+06    1.72e+07   8.61e-01   1.29e+00  9.00e+04        1    3.25e-04    8.41e-04

   3  6.747421e+07    8.38e+05    5.47e+06   3.58e-01   1.30e+00  2.70e+05        1    3.00e-04    1.16e-03

   4  6.737649e+07    9.77e+04    1.74e+06   1.30e-01   1.31e+00  8.10e+05        1    3.48e-04    1.53e-03

   5  6.736609e+07    1.04e+04    5.50e+05   4.33e-02   1.31e+00  2.43e+06        1    3.57e-04    1.94e-03

   6  6.736503e+07    1.06e+03    1.74e+05   1.40e-02   1.32e+00  7.29e+06        1    3.46e-04    2.30e-03

   7  6.736492e+07    1.08e+02    5.52e+04   4.45e-03   1.32e+00  2.19e+07        1    3.59e-04    2.69e-03

Ceres Solver Report: Iterations: 8, Initial cost: 1.201187e+08, Final cost: 6.736492e+07, Termination: CONVERGENCE

Found line: (a=0.716242, b=-1, c=86.5045)

[       OK ] CeresSolver.FitLineNoiseAndOutliers (4 ms)

[ RUN      ] CeresSolver.FitLineNoiseAndOutliersWithHuberLoss

iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time

   0  7.322971e+05    0.00e+00    7.55e+05   0.00e+00   0.00e+00  1.00e+04        0    1.11e-04    1.46e-04

   1  3.680884e+05    3.64e+05    7.92e+05   8.25e+01   2.14e+00  3.00e+04        1    3.48e-04    5.17e-04

   2  3.007535e+05    6.73e+04    3.78e+04   1.67e+01   1.89e+00  9.00e+04        1    3.40e-04    8.80e-04

   3  3.005574e+05    1.96e+02    6.16e+02   7.59e-01   1.06e+00  2.70e+05        1    3.59e-04    1.26e-03

   4  3.005569e+05    5.12e-01    2.02e+01   3.93e-02   1.04e+00  8.10e+05        1    3.59e-04    1.64e-03

Ceres Solver Report: Iterations: 5, Initial cost: 7.322971e+05, Final cost: 3.005569e+05, Termination: CONVERGENCE

Found line: (a=0.500503, b=-1, c=100.006)

[       OK ] CeresSolver.FitLineNoiseAndOutliersWithHuberLoss (3 ms)

[----------] 5 tests from CeresSolver (11 ms total)

[----------] Global test environment tear-down

[==========] 5 tests from 1 test suite ran. (11 ms total)

[  PASSED  ] 5 tests.

The command "./build/test_ceres_solver" exited with 0.

290.90s$ ./build/test_sfm_ba

Running main() from /home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/libs/3rdparty/libgtest/googletest/src/gtest_main.cc

[==========] Running 1 test from 1 test suite.

[----------] Global test environment set-up.

[----------] 1 test from SFM

[ RUN      ] SFM.ReconstructNViews

32 images

detecting points...

matching points...

0% - Cameras 0-1 (IMG_3023.JPG-IMG_3024.JPG): 1159 matches

0% - Cameras 0-2 (IMG_3023.JPG-IMG_3025.JPG): 442 matches

1% - Cameras 0-3 (IMG_3023.JPG-IMG_3026.JPG): 148 matches

1% - Cameras 0-4 (IMG_3023.JPG-IMG_3027.JPG): 53 matches

2% - Cameras 0-11 (IMG_3023.JPG-IMG_3034.JPG): 19 matches

3% - Cameras 16-11 (IMG_3039.JPG-IMG_3034.JPG): 61 matches

3% - Cameras 16-12 (IMG_3039.JPG-IMG_3035.JPG): 171 matches

3% - Cameras 0-15 (IMG_3023.JPG-IMG_3038.JPG): 2 matches

3% - Cameras 16-13 (IMG_3039.JPG-IMG_3036.JPG): 367 matches

3% - Cameras 16-14 (IMG_3039.JPG-IMG_3037.JPG): 801 matches

3% - Cameras 16-15 (IMG_3039.JPG-IMG_3038.JPG): 1308 matches

4% - Cameras 16-17 (IMG_3039.JPG-IMG_3040.JPG): 1594 matches

4% - Cameras 16-18 (IMG_3039.JPG-IMG_3041.JPG): 1082 matches

4% - Cameras 16-19 (IMG_3039.JPG-IMG_3042.JPG): 332 matches

4% - Cameras 16-20 (IMG_3039.JPG-IMG_3043.JPG): 51 matches

5% - Cameras 0-28 (IMG_3023.JPG-IMG_3051.JPG): 518 matches

6% - Cameras 0-29 (IMG_3023.JPG-IMG_3052.JPG): 917 matches

6% - Cameras 0-30 (IMG_3023.JPG-IMG_3053.JPG): 2339 matches

6% - Cameras 0-31 (IMG_3023.JPG-IMG_3054.JPG): 1154 matches

6% - Cameras 1-0 (IMG_3024.JPG-IMG_3023.JPG): 1030 matches

6% - Cameras 1-2 (IMG_3024.JPG-IMG_3025.JPG): 1153 matches

7% - Cameras 1-3 (IMG_3024.JPG-IMG_3026.JPG): 368 matches

7% - Cameras 1-4 (IMG_3024.JPG-IMG_3027.JPG): 143 matches

9% - Cameras 1-14 (IMG_3024.JPG-IMG_3037.JPG): 28 matches

9% - Cameras 17-11 (IMG_3040.JPG-IMG_3034.JPG): 20 matches

9% - Cameras 17-12 (IMG_3040.JPG-IMG_3035.JPG): 89 matches

9% - Cameras 17-13 (IMG_3040.JPG-IMG_3036.JPG): 257 matches

10% - Cameras 17-14 (IMG_3040.JPG-IMG_3037.JPG): 369 matches

10% - Cameras 17-15 (IMG_3040.JPG-IMG_3038.JPG): 830 matches

10% - Cameras 17-16 (IMG_3040.JPG-IMG_3039.JPG): 1642 matches

10% - Cameras 17-18 (IMG_3040.JPG-IMG_3041.JPG): 1637 matches

11% - Cameras 17-19 (IMG_3040.JPG-IMG_3042.JPG): 1093 matches

11% - Cameras 17-20 (IMG_3040.JPG-IMG_3043.JPG): 106 matches

11% - Cameras 1-28 (IMG_3024.JPG-IMG_3051.JPG): 113 matches

12% - Cameras 1-29 (IMG_3024.JPG-IMG_3052.JPG): 309 matches

12% - Cameras 1-30 (IMG_3024.JPG-IMG_3053.JPG): 918 matches

12% - Cameras 1-31 (IMG_3024.JPG-IMG_3054.JPG): 1607 matches

12% - Cameras 2-0 (IMG_3025.JPG-IMG_3023.JPG): 534 matches

12% - Cameras 2-1 (IMG_3025.JPG-IMG_3024.JPG): 1128 matches

13% - Cameras 2-3 (IMG_3025.JPG-IMG_3026.JPG): 1261 matches

13% - Cameras 2-4 (IMG_3025.JPG-IMG_3027.JPG): 646 matches

13% - Cameras 2-5 (IMG_3025.JPG-IMG_3028.JPG): 113 matches

13% - Cameras 2-6 (IMG_3025.JPG-IMG_3029.JPG): 49 matches

13% - Cameras 2-7 (IMG_3025.JPG-IMG_3030.JPG): 44 matches

16% - Cameras 18-12 (IMG_3041.JPG-IMG_3035.JPG): 30 matches

16% - Cameras 18-13 (IMG_3041.JPG-IMG_3036.JPG): 110 matches

16% - Cameras 18-14 (IMG_3041.JPG-IMG_3037.JPG): 175 matches

16% - Cameras 18-15 (IMG_3041.JPG-IMG_3038.JPG): 309 matches

17% - Cameras 18-16 (IMG_3041.JPG-IMG_3039.JPG): 1139 matches

17% - Cameras 18-17 (IMG_3041.JPG-IMG_3040.JPG): 1646 matches

17% - Cameras 18-19 (IMG_3041.JPG-IMG_3042.JPG): 1339 matches

17% - Cameras 18-20 (IMG_3041.JPG-IMG_3043.JPG): 321 matches

17% - Cameras 18-21 (IMG_3041.JPG-IMG_3044.JPG): 109 matches

18% - Cameras 2-28 (IMG_3025.JPG-IMG_3051.JPG): 26 matches

18% - Cameras 2-29 (IMG_3025.JPG-IMG_3052.JPG): 177 matches

18% - Cameras 2-30 (IMG_3025.JPG-IMG_3053.JPG): 367 matches

18% - Cameras 2-31 (IMG_3025.JPG-IMG_3054.JPG): 777 matches

18% - Cameras 3-0 (IMG_3026.JPG-IMG_3023.JPG): 170 matches

19% - Cameras 3-1 (IMG_3026.JPG-IMG_3024.JPG): 361 matches

19% - Cameras 3-2 (IMG_3026.JPG-IMG_3025.JPG): 1188 matches

19% - Cameras 3-4 (IMG_3026.JPG-IMG_3027.JPG): 1525 matches

19% - Cameras 3-5 (IMG_3026.JPG-IMG_3028.JPG): 717 matches

19% - Cameras 3-6 (IMG_3026.JPG-IMG_3029.JPG): 300 matches

20% - Cameras 3-7 (IMG_3026.JPG-IMG_3030.JPG): 74 matches

21% - Cameras 3-12 (IMG_3026.JPG-IMG_3035.JPG): 3 matches

22% - Cameras 19-13 (IMG_3042.JPG-IMG_3036.JPG): 32 matches

22% - Cameras 19-14 (IMG_3042.JPG-IMG_3037.JPG): 85 matches

22% - Cameras 19-15 (IMG_3042.JPG-IMG_3038.JPG): 99 matches

22% - Cameras 19-16 (IMG_3042.JPG-IMG_3039.JPG): 229 matches

23% - Cameras 19-17 (IMG_3042.JPG-IMG_3040.JPG): 840 matches

23% - Cameras 19-18 (IMG_3042.JPG-IMG_3041.JPG): 1006 matches

23% - Cameras 19-20 (IMG_3042.JPG-IMG_3043.JPG): 915 matches

23% - Cameras 19-21 (IMG_3042.JPG-IMG_3044.JPG): 382 matches

23% - Cameras 19-22 (IMG_3042.JPG-IMG_3045.JPG): 179 matches

24% - Cameras 19-23 (IMG_3042.JPG-IMG_3046.JPG): 97 matches

24% - Cameras 19-24 (IMG_3042.JPG-IMG_3047.JPG): 97 matches

24% - Cameras 19-25 (IMG_3042.JPG-IMG_3048.JPG): 42 matches

24% - Cameras 19-26 (IMG_3042.JPG-IMG_3049.JPG): 21 matches

24% - Cameras 3-29 (IMG_3026.JPG-IMG_3052.JPG): 62 matches

24% - Cameras 3-30 (IMG_3026.JPG-IMG_3053.JPG): 128 matches

25% - Cameras 3-31 (IMG_3026.JPG-IMG_3054.JPG): 244 matches

25% - Cameras 4-0 (IMG_3027.JPG-IMG_3023.JPG): 77 matches

25% - Cameras 4-1 (IMG_3027.JPG-IMG_3024.JPG): 151 matches

25% - Cameras 4-2 (IMG_3027.JPG-IMG_3025.JPG): 660 matches

26% - Cameras 4-3 (IMG_3027.JPG-IMG_3026.JPG): 1695 matches

26% - Cameras 4-5 (IMG_3027.JPG-IMG_3028.JPG): 1404 matches

26% - Cameras 4-6 (IMG_3027.JPG-IMG_3029.JPG): 1059 matches

26% - Cameras 4-7 (IMG_3027.JPG-IMG_3030.JPG): 297 matches

26% - Cameras 4-8 (IMG_3027.JPG-IMG_3031.JPG): 145 matches

27% - Cameras 4-9 (IMG_3027.JPG-IMG_3032.JPG): 123 matches

27% - Cameras 4-10 (IMG_3027.JPG-IMG_3033.JPG): 122 matches

27% - Cameras 4-11 (IMG_3027.JPG-IMG_3034.JPG): 109 matches

27% - Cameras 4-12 (IMG_3027.JPG-IMG_3035.JPG): 4 matches

28% - Cameras 20-14 (IMG_3043.JPG-IMG_3037.JPG): 8 matches

28% - Cameras 20-15 (IMG_3043.JPG-IMG_3038.JPG): 26 matches

28% - Cameras 20-16 (IMG_3043.JPG-IMG_3039.JPG): 65 matches

29% - Cameras 20-17 (IMG_3043.JPG-IMG_3040.JPG): 125 matches

29% - Cameras 20-18 (IMG_3043.JPG-IMG_3041.JPG): 394 matches

29% - Cameras 20-19 (IMG_3043.JPG-IMG_3042.JPG): 947 matches

29% - Cameras 20-21 (IMG_3043.JPG-IMG_3044.JPG): 777 matches

29% - Cameras 20-22 (IMG_3043.JPG-IMG_3045.JPG): 397 matches

30% - Cameras 20-23 (IMG_3043.JPG-IMG_3046.JPG): 342 matches

30% - Cameras 20-24 (IMG_3043.JPG-IMG_3047.JPG): 246 matches

30% - Cameras 20-25 (IMG_3043.JPG-IMG_3048.JPG): 146 matches

30% - Cameras 20-26 (IMG_3043.JPG-IMG_3049.JPG): 81 matches

30% - Cameras 20-27 (IMG_3043.JPG-IMG_3050.JPG): 27 matches

31% - Cameras 4-30 (IMG_3027.JPG-IMG_3053.JPG): 67 matches

31% - Cameras 4-31 (IMG_3027.JPG-IMG_3054.JPG): 93 matches

32% - Cameras 5-1 (IMG_3028.JPG-IMG_3024.JPG): 49 matches

32% - Cameras 5-2 (IMG_3028.JPG-IMG_3025.JPG): 150 matches

32% - Cameras 5-3 (IMG_3028.JPG-IMG_3026.JPG): 852 matches

32% - Cameras 5-4 (IMG_3028.JPG-IMG_3027.JPG): 1396 matches

33% - Cameras 5-6 (IMG_3028.JPG-IMG_3029.JPG): 1780 matches

33% - Cameras 5-7 (IMG_3028.JPG-IMG_3030.JPG): 1044 matches

33% - Cameras 5-8 (IMG_3028.JPG-IMG_3031.JPG): 374 matches

33% - Cameras 5-9 (IMG_3028.JPG-IMG_3032.JPG): 310 matches

33% - Cameras 5-10 (IMG_3028.JPG-IMG_3033.JPG): 294 matches

34% - Cameras 5-11 (IMG_3028.JPG-IMG_3034.JPG): 163 matches

34% - Cameras 21-17 (IMG_3044.JPG-IMG_3040.JPG): 42 matches

35% - Cameras 21-18 (IMG_3044.JPG-IMG_3041.JPG): 102 matches

35% - Cameras 21-19 (IMG_3044.JPG-IMG_3042.JPG): 384 matches

35% - Cameras 21-20 (IMG_3044.JPG-IMG_3043.JPG): 834 matches

35% - Cameras 21-22 (IMG_3044.JPG-IMG_3045.JPG): 810 matches

35% - Cameras 21-23 (IMG_3044.JPG-IMG_3046.JPG): 650 matches

36% - Cameras 21-24 (IMG_3044.JPG-IMG_3047.JPG): 402 matches

36% - Cameras 21-25 (IMG_3044.JPG-IMG_3048.JPG): 289 matches

36% - Cameras 21-26 (IMG_3044.JPG-IMG_3049.JPG): 205 matches

36% - Cameras 21-27 (IMG_3044.JPG-IMG_3050.JPG): 64 matches

36% - Cameras 21-28 (IMG_3044.JPG-IMG_3051.JPG): 27 matches

38% - Cameras 5-31 (IMG_3028.JPG-IMG_3054.JPG): 9 matches

39% - Cameras 6-2 (IMG_3029.JPG-IMG_3025.JPG): 51 matches

39% - Cameras 6-3 (IMG_3029.JPG-IMG_3026.JPG): 308 matches

39% - Cameras 6-4 (IMG_3029.JPG-IMG_3027.JPG): 884 matches

39% - Cameras 6-5 (IMG_3029.JPG-IMG_3028.JPG): 1689 matches

40% - Cameras 6-7 (IMG_3029.JPG-IMG_3030.JPG): 1558 matches

40% - Cameras 6-8 (IMG_3029.JPG-IMG_3031.JPG): 825 matches

40% - Cameras 6-9 (IMG_3029.JPG-IMG_3032.JPG): 465 matches

40% - Cameras 6-10 (IMG_3029.JPG-IMG_3033.JPG): 355 matches

40% - Cameras 6-11 (IMG_3029.JPG-IMG_3034.JPG): 133 matches

41% - Cameras 22-18 (IMG_3045.JPG-IMG_3041.JPG): 32 matches

41% - Cameras 22-19 (IMG_3045.JPG-IMG_3042.JPG): 136 matches

41% - Cameras 22-20 (IMG_3045.JPG-IMG_3043.JPG): 456 matches

41% - Cameras 22-21 (IMG_3045.JPG-IMG_3044.JPG): 872 matches

41% - Cameras 22-23 (IMG_3045.JPG-IMG_3046.JPG): 1254 matches

41% - Cameras 22-24 (IMG_3045.JPG-IMG_3047.JPG): 980 matches

42% - Cameras 22-25 (IMG_3045.JPG-IMG_3048.JPG): 466 matches

42% - Cameras 22-26 (IMG_3045.JPG-IMG_3049.JPG): 298 matches

42% - Cameras 22-27 (IMG_3045.JPG-IMG_3050.JPG): 153 matches

42% - Cameras 22-28 (IMG_3045.JPG-IMG_3051.JPG): 82 matches

46% - Cameras 7-3 (IMG_3030.JPG-IMG_3026.JPG): 101 matches

46% - Cameras 7-4 (IMG_3030.JPG-IMG_3027.JPG): 341 matches

46% - Cameras 7-5 (IMG_3030.JPG-IMG_3028.JPG): 1015 matches

46% - Cameras 7-6 (IMG_3030.JPG-IMG_3029.JPG): 1554 matches

46% - Cameras 7-8 (IMG_3030.JPG-IMG_3031.JPG): 1203 matches

47% - Cameras 23-19 (IMG_3046.JPG-IMG_3042.JPG): 45 matches

47% - Cameras 7-9 (IMG_3030.JPG-IMG_3032.JPG): 759 matches

47% - Cameras 23-20 (IMG_3046.JPG-IMG_3043.JPG): 282 matches

47% - Cameras 23-21 (IMG_3046.JPG-IMG_3044.JPG): 677 matches

47% - Cameras 7-10 (IMG_3030.JPG-IMG_3033.JPG): 415 matches

47% - Cameras 23-22 (IMG_3046.JPG-IMG_3045.JPG): 1307 matches

47% - Cameras 7-11 (IMG_3030.JPG-IMG_3034.JPG): 160 matches

47% - Cameras 23-24 (IMG_3046.JPG-IMG_3047.JPG): 1353 matches

47% - Cameras 23-25 (IMG_3046.JPG-IMG_3048.JPG): 871 matches

48% - Cameras 23-26 (IMG_3046.JPG-IMG_3049.JPG): 421 matches

48% - Cameras 23-27 (IMG_3046.JPG-IMG_3050.JPG): 222 matches

48% - Cameras 23-28 (IMG_3046.JPG-IMG_3051.JPG): 71 matches

52% - Cameras 8-3 (IMG_3031.JPG-IMG_3026.JPG): 6 matches

52% - Cameras 8-4 (IMG_3031.JPG-IMG_3027.JPG): 180 matches

53% - Cameras 8-5 (IMG_3031.JPG-IMG_3028.JPG): 394 matches

53% - Cameras 24-19 (IMG_3047.JPG-IMG_3042.JPG): 15 matches

53% - Cameras 8-6 (IMG_3031.JPG-IMG_3029.JPG): 832 matches

53% - Cameras 24-20 (IMG_3047.JPG-IMG_3043.JPG): 208 matches

53% - Cameras 8-7 (IMG_3031.JPG-IMG_3030.JPG): 1242 matches

53% - Cameras 24-21 (IMG_3047.JPG-IMG_3044.JPG): 374 matches

53% - Cameras 8-9 (IMG_3031.JPG-IMG_3032.JPG): 1573 matches

53% - Cameras 24-22 (IMG_3047.JPG-IMG_3045.JPG): 973 matches

53% - Cameras 8-10 (IMG_3031.JPG-IMG_3033.JPG): 659 matches

53% - Cameras 24-23 (IMG_3047.JPG-IMG_3046.JPG): 1331 matches

54% - Cameras 8-11 (IMG_3031.JPG-IMG_3034.JPG): 135 matches

54% - Cameras 24-25 (IMG_3047.JPG-IMG_3048.JPG): 1352 matches

54% - Cameras 24-26 (IMG_3047.JPG-IMG_3049.JPG): 722 matches

54% - Cameras 24-27 (IMG_3047.JPG-IMG_3050.JPG): 317 matches

54% - Cameras 24-28 (IMG_3047.JPG-IMG_3051.JPG): 98 matches

58% - Cameras 9-4 (IMG_3032.JPG-IMG_3027.JPG): 84 matches

59% - Cameras 9-5 (IMG_3032.JPG-IMG_3028.JPG): 274 matches

59% - Cameras 9-6 (IMG_3032.JPG-IMG_3029.JPG): 450 matches

59% - Cameras 9-7 (IMG_3032.JPG-IMG_3030.JPG): 752 matches

59% - Cameras 25-19 (IMG_3048.JPG-IMG_3042.JPG): 30 matches

59% - Cameras 9-8 (IMG_3032.JPG-IMG_3031.JPG): 1595 matches

59% - Cameras 25-20 (IMG_3048.JPG-IMG_3043.JPG): 121 matches

59% - Cameras 9-10 (IMG_3032.JPG-IMG_3033.JPG): 1345 matches

59% - Cameras 25-21 (IMG_3048.JPG-IMG_3044.JPG): 275 matches

60% - Cameras 9-11 (IMG_3032.JPG-IMG_3034.JPG): 402 matches

60% - Cameras 25-22 (IMG_3048.JPG-IMG_3045.JPG): 484 matches

60% - Cameras 9-12 (IMG_3032.JPG-IMG_3035.JPG): 27 matches

60% - Cameras 25-23 (IMG_3048.JPG-IMG_3046.JPG): 871 matches

60% - Cameras 9-13 (IMG_3032.JPG-IMG_3036.JPG): 8 matches

60% - Cameras 25-24 (IMG_3048.JPG-IMG_3047.JPG): 1344 matches

60% - Cameras 25-26 (IMG_3048.JPG-IMG_3049.JPG): 933 matches

61% - Cameras 25-27 (IMG_3048.JPG-IMG_3050.JPG): 483 matches

61% - Cameras 25-28 (IMG_3048.JPG-IMG_3051.JPG): 107 matches

64% - Cameras 10-4 (IMG_3033.JPG-IMG_3027.JPG): 98 matches

64% - Cameras 10-5 (IMG_3033.JPG-IMG_3028.JPG): 276 matches

65% - Cameras 10-6 (IMG_3033.JPG-IMG_3029.JPG): 339 matches

65% - Cameras 10-7 (IMG_3033.JPG-IMG_3030.JPG): 405 matches

65% - Cameras 10-8 (IMG_3033.JPG-IMG_3031.JPG): 606 matches

65% - Cameras 10-9 (IMG_3033.JPG-IMG_3032.JPG): 1331 matches

65% - Cameras 10-11 (IMG_3033.JPG-IMG_3034.JPG): 1153 matches

65% - Cameras 10-12 (IMG_3033.JPG-IMG_3035.JPG): 470 matches

66% - Cameras 10-13 (IMG_3033.JPG-IMG_3036.JPG): 48 matches

66% - Cameras 10-15 (IMG_3033.JPG-IMG_3038.JPG): 4 matches

66% - Cameras 26-19 (IMG_3049.JPG-IMG_3042.JPG): 27 matches

66% - Cameras 26-20 (IMG_3049.JPG-IMG_3043.JPG): 82 matches

67% - Cameras 26-21 (IMG_3049.JPG-IMG_3044.JPG): 195 matches

67% - Cameras 26-22 (IMG_3049.JPG-IMG_3045.JPG): 328 matches

67% - Cameras 26-23 (IMG_3049.JPG-IMG_3046.JPG): 465 matches

67% - Cameras 26-24 (IMG_3049.JPG-IMG_3047.JPG): 709 matches

67% - Cameras 26-25 (IMG_3049.JPG-IMG_3048.JPG): 911 matches

68% - Cameras 26-27 (IMG_3049.JPG-IMG_3050.JPG): 883 matches

68% - Cameras 26-28 (IMG_3049.JPG-IMG_3051.JPG): 295 matches

68% - Cameras 26-29 (IMG_3049.JPG-IMG_3052.JPG): 2 matches

69% - Cameras 27-0 (IMG_3050.JPG-IMG_3023.JPG): 33 matches

69% - Cameras 27-1 (IMG_3050.JPG-IMG_3024.JPG): 23 matches

70% - Cameras 11-4 (IMG_3034.JPG-IMG_3027.JPG): 97 matches

70% - Cameras 11-5 (IMG_3034.JPG-IMG_3028.JPG): 147 matches

70% - Cameras 11-6 (IMG_3034.JPG-IMG_3029.JPG): 139 matches

70% - Cameras 11-7 (IMG_3034.JPG-IMG_3030.JPG): 149 matches

70% - Cameras 11-8 (IMG_3034.JPG-IMG_3031.JPG): 185 matches

71% - Cameras 11-9 (IMG_3034.JPG-IMG_3032.JPG): 445 matches

71% - Cameras 11-10 (IMG_3034.JPG-IMG_3033.JPG): 1103 matches

71% - Cameras 11-12 (IMG_3034.JPG-IMG_3035.JPG): 1255 matches

71% - Cameras 11-13 (IMG_3034.JPG-IMG_3036.JPG): 479 matches

71% - Cameras 11-14 (IMG_3034.JPG-IMG_3037.JPG): 178 matches

71% - Cameras 11-15 (IMG_3034.JPG-IMG_3038.JPG): 115 matches

72% - Cameras 11-16 (IMG_3034.JPG-IMG_3039.JPG): 48 matches

73% - Cameras 27-20 (IMG_3050.JPG-IMG_3043.JPG): 25 matches

74% - Cameras 27-21 (IMG_3050.JPG-IMG_3044.JPG): 94 matches

74% - Cameras 27-22 (IMG_3050.JPG-IMG_3045.JPG): 185 matches

74% - Cameras 27-23 (IMG_3050.JPG-IMG_3046.JPG): 293 matches

74% - Cameras 27-24 (IMG_3050.JPG-IMG_3047.JPG): 376 matches

75% - Cameras 27-25 (IMG_3050.JPG-IMG_3048.JPG): 506 matches

75% - Cameras 27-26 (IMG_3050.JPG-IMG_3049.JPG): 803 matches

75% - Cameras 27-28 (IMG_3050.JPG-IMG_3051.JPG): 783 matches

76% - Cameras 27-29 (IMG_3050.JPG-IMG_3052.JPG): 252 matches

76% - Cameras 27-30 (IMG_3050.JPG-IMG_3053.JPG): 50 matches

76% - Cameras 27-31 (IMG_3050.JPG-IMG_3054.JPG): 28 matches

76% - Cameras 12-9 (IMG_3035.JPG-IMG_3032.JPG): 4 matches

76% - Cameras 28-0 (IMG_3051.JPG-IMG_3023.JPG): 492 matches

76% - Cameras 12-10 (IMG_3035.JPG-IMG_3033.JPG): 497 matches

76% - Cameras 12-11 (IMG_3035.JPG-IMG_3034.JPG): 1313 matches

76% - Cameras 28-1 (IMG_3051.JPG-IMG_3024.JPG): 167 matches

77% - Cameras 12-13 (IMG_3035.JPG-IMG_3036.JPG): 1109 matches

77% - Cameras 28-2 (IMG_3051.JPG-IMG_3025.JPG): 47 matches

77% - Cameras 12-14 (IMG_3035.JPG-IMG_3037.JPG): 455 matches

77% - Cameras 12-15 (IMG_3035.JPG-IMG_3038.JPG): 303 matches

77% - Cameras 12-16 (IMG_3035.JPG-IMG_3039.JPG): 173 matches

77% - Cameras 12-17 (IMG_3035.JPG-IMG_3040.JPG): 85 matches

77% - Cameras 12-18 (IMG_3035.JPG-IMG_3041.JPG): 34 matches

81% - Cameras 28-21 (IMG_3051.JPG-IMG_3044.JPG): 17 matches

81% - Cameras 28-22 (IMG_3051.JPG-IMG_3045.JPG): 75 matches

81% - Cameras 28-23 (IMG_3051.JPG-IMG_3046.JPG): 125 matches

82% - Cameras 28-24 (IMG_3051.JPG-IMG_3047.JPG): 120 matches

82% - Cameras 13-9 (IMG_3036.JPG-IMG_3032.JPG): 24 matches

82% - Cameras 28-25 (IMG_3051.JPG-IMG_3048.JPG): 168 matches

82% - Cameras 13-10 (IMG_3036.JPG-IMG_3033.JPG): 16 matches

82% - Cameras 13-11 (IMG_3036.JPG-IMG_3034.JPG): 484 matches

82% - Cameras 28-26 (IMG_3051.JPG-IMG_3049.JPG): 303 matches

82% - Cameras 13-12 (IMG_3036.JPG-IMG_3035.JPG): 1119 matches

82% - Cameras 28-27 (IMG_3051.JPG-IMG_3050.JPG): 778 matches

82% - Cameras 13-14 (IMG_3036.JPG-IMG_3037.JPG): 1032 matches

82% - Cameras 28-29 (IMG_3051.JPG-IMG_3052.JPG): 923 matches

83% - Cameras 13-15 (IMG_3036.JPG-IMG_3038.JPG): 863 matches

83% - Cameras 13-16 (IMG_3036.JPG-IMG_3039.JPG): 405 matches

83% - Cameras 28-30 (IMG_3051.JPG-IMG_3053.JPG): 568 matches

83% - Cameras 13-17 (IMG_3036.JPG-IMG_3040.JPG): 218 matches

83% - Cameras 28-31 (IMG_3051.JPG-IMG_3054.JPG): 121 matches

83% - Cameras 13-18 (IMG_3036.JPG-IMG_3041.JPG): 107 matches

83% - Cameras 29-0 (IMG_3052.JPG-IMG_3023.JPG): 914 matches

83% - Cameras 13-19 (IMG_3036.JPG-IMG_3042.JPG): 19 matches

83% - Cameras 29-1 (IMG_3052.JPG-IMG_3024.JPG): 369 matches

84% - Cameras 29-2 (IMG_3052.JPG-IMG_3025.JPG): 155 matches

84% - Cameras 29-3 (IMG_3052.JPG-IMG_3026.JPG): 50 matches

88% - Cameras 14-10 (IMG_3037.JPG-IMG_3033.JPG): 16 matches

88% - Cameras 14-11 (IMG_3037.JPG-IMG_3034.JPG): 141 matches

88% - Cameras 14-12 (IMG_3037.JPG-IMG_3035.JPG): 417 matches

88% - Cameras 29-25 (IMG_3052.JPG-IMG_3048.JPG): 20 matches

88% - Cameras 14-13 (IMG_3037.JPG-IMG_3036.JPG): 985 matches

89% - Cameras 14-15 (IMG_3037.JPG-IMG_3038.JPG): 1333 matches

89% - Cameras 14-16 (IMG_3037.JPG-IMG_3039.JPG): 774 matches

89% - Cameras 29-27 (IMG_3052.JPG-IMG_3050.JPG): 255 matches

89% - Cameras 14-17 (IMG_3037.JPG-IMG_3040.JPG): 314 matches

89% - Cameras 29-28 (IMG_3052.JPG-IMG_3051.JPG): 903 matches

89% - Cameras 14-18 (IMG_3037.JPG-IMG_3041.JPG): 165 matches

89% - Cameras 29-30 (IMG_3052.JPG-IMG_3053.JPG): 963 matches

89% - Cameras 14-19 (IMG_3037.JPG-IMG_3042.JPG): 50 matches

89% - Cameras 29-31 (IMG_3052.JPG-IMG_3054.JPG): 621 matches

90% - Cameras 30-0 (IMG_3053.JPG-IMG_3023.JPG): 2289 matches

90% - Cameras 30-1 (IMG_3053.JPG-IMG_3024.JPG): 1044 matches

90% - Cameras 30-2 (IMG_3053.JPG-IMG_3025.JPG): 324 matches

90% - Cameras 30-3 (IMG_3053.JPG-IMG_3026.JPG): 117 matches

91% - Cameras 30-4 (IMG_3053.JPG-IMG_3027.JPG): 38 matches

92% - Cameras 15-2 (IMG_3038.JPG-IMG_3025.JPG): 1 matches

94% - Cameras 15-11 (IMG_3038.JPG-IMG_3034.JPG): 108 matches

94% - Cameras 15-12 (IMG_3038.JPG-IMG_3035.JPG): 252 matches

95% - Cameras 15-13 (IMG_3038.JPG-IMG_3036.JPG): 837 matches

95% - Cameras 15-14 (IMG_3038.JPG-IMG_3037.JPG): 1312 matches

95% - Cameras 15-16 (IMG_3038.JPG-IMG_3039.JPG): 1297 matches

95% - Cameras 30-27 (IMG_3053.JPG-IMG_3050.JPG): 8 matches

95% - Cameras 15-17 (IMG_3038.JPG-IMG_3040.JPG): 862 matches

95% - Cameras 30-28 (IMG_3053.JPG-IMG_3051.JPG): 615 matches

95% - Cameras 15-18 (IMG_3038.JPG-IMG_3041.JPG): 293 matches

95% - Cameras 30-29 (IMG_3053.JPG-IMG_3052.JPG): 950 matches

96% - Cameras 15-19 (IMG_3038.JPG-IMG_3042.JPG): 75 matches

96% - Cameras 30-31 (IMG_3053.JPG-IMG_3054.JPG): 976 matches

96% - Cameras 31-0 (IMG_3054.JPG-IMG_3023.JPG): 1135 matches

96% - Cameras 31-1 (IMG_3054.JPG-IMG_3024.JPG): 1622 matches

96% - Cameras 31-2 (IMG_3054.JPG-IMG_3025.JPG): 856 matches

97% - Cameras 31-3 (IMG_3054.JPG-IMG_3026.JPG): 213 matches

97% - Cameras 31-4 (IMG_3054.JPG-IMG_3027.JPG): 69 matches

97% - Cameras 15-28 (IMG_3038.JPG-IMG_3051.JPG): 1 matches

100% - Cameras 31-28 (IMG_3054.JPG-IMG_3051.JPG): 141 matches

100% - Cameras 31-29 (IMG_3054.JPG-IMG_3052.JPG): 571 matches

100% - Cameras 31-30 (IMG_3054.JPG-IMG_3053.JPG): 881 matches

Initial alignment from cameras #0 and #1 (IMG_3023.JPG, IMG_3024.JPG)

Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546

Before BA projections: 89% inliers with MSE=1.71016

    Camera #0 projections: 89% inliers (1037/1159) with MSE=1.68797

    Camera #1 projections: 89% inliers (1035/1159) with MSE=1.73239

After BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

After BA tie poits: 0% old + 11% new = 11% total outliers

After BA projections: 89% inliers with MSE=0.36941

    Camera #0 projections: 89% inliers (1027/1159) with MSE=0.374369

    Camera #1 projections: 89% inliers (1028/1159) with MSE=0.364456

Append camera #2 (IMG_3025.JPG) to alignment via 789 common points

Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546

Before BA projections: 63% inliers with MSE=0.824452

    Camera #0 projections: 83% inliers (1107/1336) with MSE=0.438259

    Camera #1 projections: 77% inliers (1373/1793) with MSE=0.72779

    Camera #2 projections: 31% inliers (506/1638) with MSE=1.93163

After BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.72678, 0.121995, 0.704228] -> [-1.94328, 0.0213525, 0.576101]

After BA tie poits: 7% old + 20% new = 26% total outliers

After BA projections: 88% inliers with MSE=0.668536

    Camera #0 projections: 84% inliers (1128/1336) with MSE=1.00061

    Camera #1 projections: 89% inliers (1588/1793) with MSE=0.765473

    Camera #2 projections: 91% inliers (1497/1638) with MSE=0.31549

Append camera #3 (IMG_3026.JPG) to alignment via 595 common points

Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546

Before BA projections: 77% inliers with MSE=0.842872

    Camera #0 projections: 84% inliers (1141/1351) with MSE=0.994809

    Camera #1 projections: 88% inliers (1618/1833) with MSE=0.781199

    Camera #2 projections: 82% inliers (1867/2279) with MSE=0.51582

    Camera #3 projections: 44% inliers (583/1316) with MSE=1.76402

After BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.94328, 0.0213525, 0.576101] -> [-1.8807, 0.0104714, 0.49497]

Camera #3 center: [-2.80188, 0.0930917, 1.10575] -> [-2.69668, 0.016959, 0.898982]

After BA tie poits: 19% old + 14% new = 33% total outliers

After BA projections: 77% inliers with MSE=0.431508

    Camera #0 projections: 83% inliers (1122/1351) with MSE=1.07945

    Camera #1 projections: 71% inliers (1310/1833) with MSE=0.48376

    Camera #2 projections: 68% inliers (1551/2279) with MSE=0.160482

    Camera #3 projections: 92% inliers (1217/1316) with MSE=0.123311

Append camera #4 (IMG_3027.JPG) to alignment via 605 common points

Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546

Before BA projections: 71% inliers with MSE=0.506283

    Camera #0 projections: 83% inliers (1128/1358) with MSE=1.08304

    Camera #1 projections: 72% inliers (1318/1843) with MSE=0.482579

    Camera #2 projections: 66% inliers (1621/2472) with MSE=0.182836

    Camera #3 projections: 79% inliers (1824/2300) with MSE=0.182579

    Camera #4 projections: 62% inliers (1241/2007) with MSE=0.905477

After BA camera: k1=-3.20613e-09, k2=-1.60859e-13, f=1714.46, cx=317.494, cy=509.4

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.8807, 0.0104714, 0.49497] -> [-1.86391, 0.0228595, 0.523307]

Camera #3 center: [-2.69668, 0.016959, 0.898982] -> [-2.65241, 0.0436111, 0.944547]

Camera #4 center: [-3.30307, 0.0303596, 1.47377] -> [-3.22717, 0.0907147, 1.51949]

After BA tie poits: 23% old + 10% new = 33% total outliers

After BA projections: 66% inliers with MSE=0.201668

    Camera #0 projections: 56% inliers (762/1358) with MSE=0.30754

    Camera #1 projections: 62% inliers (1144/1843) with MSE=0.206339

    Camera #2 projections: 55% inliers (1357/2472) with MSE=0.160899

    Camera #3 projections: 73% inliers (1680/2300) with MSE=0.194574

    Camera #4 projections: 79% inliers (1594/2007) with MSE=0.189889

Append camera #5 (IMG_3028.JPG) to alignment via 858 common points

Before BA camera: k1=-3.20613e-09, k2=-1.60859e-13, f=1714.46, cx=317.494, cy=509.4

Before BA projections: 62% inliers with MSE=0.5782

    Camera #0 projections: 56% inliers (762/1358) with MSE=0.30754

    Camera #1 projections: 62% inliers (1145/1846) with MSE=0.211167

    Camera #2 projections: 55% inliers (1363/2482) with MSE=0.172923

    Camera #3 projections: 68% inliers (1715/2521) with MSE=0.25902

    Camera #4 projections: 73% inliers (1948/2679) with MSE=0.706856

    Camera #5 projections: 51% inliers (927/1824) with MSE=2.17006

After BA camera: k1=3.47794e-09, k2=-1.81054e-13, f=1788.96, cx=320.354, cy=502.927

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.86391, 0.0228595, 0.523307] -> [-1.85414, 0.0213731, 0.520991]

Camera #3 center: [-2.65241, 0.0436111, 0.944547] -> [-2.62662, 0.039849, 0.932149]

Camera #4 center: [-3.22717, 0.0907147, 1.51949] -> [-3.18575, 0.0824447, 1.48778]

Camera #5 center: [-3.77625, 0.11577, 2.23811] -> [-3.68367, 0.132115, 2.17696]

After BA tie poits: 27% old + 8% new = 35% total outliers

After BA projections: 63% inliers with MSE=0.223451

    Camera #0 projections: 54% inliers (728/1358) with MSE=0.30287

    Camera #1 projections: 57% inliers (1054/1846) with MSE=0.231164

    Camera #2 projections: 48% inliers (1184/2482) with MSE=0.154813

    Camera #3 projections: 62% inliers (1569/2521) with MSE=0.20331

    Camera #4 projections: 69% inliers (1846/2679) with MSE=0.238735

    Camera #5 projections: 87% inliers (1580/1824) with MSE=0.235289

Append camera #6 (IMG_3029.JPG) to alignment via 912 common points

Before BA camera: k1=3.47794e-09, k2=-1.81054e-13, f=1788.96, cx=320.354, cy=502.927

Before BA projections: 59% inliers with MSE=0.44745

    Camera #0 projections: 54% inliers (728/1358) with MSE=0.30287

    Camera #1 projections: 57% inliers (1054/1846) with MSE=0.231164

    Camera #2 projections: 48% inliers (1186/2484) with MSE=0.154642

    Camera #3 projections: 62% inliers (1578/2541) with MSE=0.206006

    Camera #4 projections: 65% inliers (1908/2934) with MSE=0.268742

    Camera #5 projections: 70% inliers (1947/2778) with MSE=0.347965

    Camera #6 projections: 48% inliers (1098/2269) with MSE=1.90115

After BA camera: k1=-2.07751e-07, k2=2.32726e-13, f=1556.48, cx=293.473, cy=496.542

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85414, 0.0213731, 0.520991] -> [-1.86488, 0.0343818, 0.527044]

Camera #3 center: [-2.62662, 0.039849, 0.932149] -> [-2.67736, 0.0723931, 0.953527]

Camera #4 center: [-3.18575, 0.0824447, 1.48778] -> [-3.26278, 0.141606, 1.52442]

Camera #5 center: [-3.68367, 0.132115, 2.17696] -> [-3.77046, 0.220536, 2.19018]

Camera #6 center: [-3.88682, 0.239838, 2.97259] -> [-3.99535, 0.328247, 2.95656]

After BA tie poits: 28% old + 24% new = 52% total outliers

After BA projections: 60% inliers with MSE=0.24829

    Camera #0 projections: 53% inliers (718/1358) with MSE=0.327209

    Camera #1 projections: 55% inliers (1024/1846) with MSE=0.250397

    Camera #2 projections: 44% inliers (1087/2484) with MSE=0.115438

    Camera #3 projections: 52% inliers (1321/2541) with MSE=0.175423

    Camera #4 projections: 60% inliers (1754/2934) with MSE=0.274493

    Camera #5 projections: 71% inliers (1962/2778) with MSE=0.301311

    Camera #6 projections: 85% inliers (1924/2269) with MSE=0.264848

Append camera #7 (IMG_3030.JPG) to alignment via 913 common points

Before BA camera: k1=-2.07751e-07, k2=2.32726e-13, f=1556.48, cx=293.473, cy=496.542

Before BA projections: 53% inliers with MSE=0.348671

    Camera #0 projections: 53% inliers (718/1358) with MSE=0.327209

    Camera #1 projections: 55% inliers (1024/1846) with MSE=0.250397

    Camera #2 projections: 44% inliers (1087/2484) with MSE=0.115438

    Camera #3 projections: 52% inliers (1322/2543) with MSE=0.178973

    Camera #4 projections: 60% inliers (1763/2961) with MSE=0.282233

    Camera #5 projections: 67% inliers (2008/3003) with MSE=0.350123

    Camera #6 projections: 69% inliers (2076/2998) with MSE=0.489387

    Camera #7 projections: 8% inliers (154/1962) with MSE=3.04994

After BA camera: k1=-1.12545e-07, k2=4.84097e-14, f=1549.92, cx=318.756, cy=534.083

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.86488, 0.0343818, 0.527044] -> [-1.86, 0.0249425, 0.513804]

Camera #3 center: [-2.67736, 0.0723931, 0.953527] -> [-2.65803, 0.0514599, 0.925368]

Camera #4 center: [-3.26278, 0.141606, 1.52442] -> [-3.24179, 0.10443, 1.48526]

Camera #5 center: [-3.77046, 0.220536, 2.19018] -> [-3.7607, 0.167619, 2.16665]

Camera #6 center: [-3.99535, 0.328247, 2.95656] -> [-3.99627, 0.258469, 2.9746]

Camera #7 center: [-4.38579, 0.0702431, 4.00816] -> [-4.15915, 0.350085, 3.80086]

After BA tie poits: 44% old + 9% new = 53% total outliers

After BA projections: 48% inliers with MSE=0.164313

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.319464

    Camera #1 projections: 55% inliers (1009/1846) with MSE=0.224352

    Camera #2 projections: 40% inliers (996/2484) with MSE=0.0969938

    Camera #3 projections: 36% inliers (922/2543) with MSE=0.109787

    Camera #4 projections: 34% inliers (998/2961) with MSE=0.157516

    Camera #5 projections: 40% inliers (1205/3003) with MSE=0.187052

    Camera #6 projections: 52% inliers (1552/2998) with MSE=0.142052

    Camera #7 projections: 89% inliers (1744/1962) with MSE=0.141677

Append camera #8 (IMG_3031.JPG) to alignment via 892 common points

Before BA camera: k1=-1.12545e-07, k2=4.84097e-14, f=1549.92, cx=318.756, cy=534.083

Before BA projections: 44% inliers with MSE=0.285288

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.319464

    Camera #1 projections: 55% inliers (1009/1846) with MSE=0.224352

    Camera #2 projections: 40% inliers (996/2484) with MSE=0.0969938

    Camera #3 projections: 36% inliers (922/2543) with MSE=0.109787

    Camera #4 projections: 34% inliers (1000/2976) with MSE=0.165912

    Camera #5 projections: 40% inliers (1208/3036) with MSE=0.190384

    Camera #6 projections: 49% inliers (1571/3221) with MSE=0.164641

    Camera #7 projections: 74% inliers (1866/2512) with MSE=0.25625

    Camera #8 projections: 17% inliers (303/1773) with MSE=3.13779

After BA camera: k1=-7.1155e-08, k2=-1.42973e-14, f=1687.64, cx=320.66, cy=520.061

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.86, 0.0249425, 0.513804] -> [-1.85487, 0.0223696, 0.521142]

Camera #3 center: [-2.65803, 0.0514599, 0.925368] -> [-2.64111, 0.0452635, 0.944877]

Camera #4 center: [-3.24179, 0.10443, 1.48526] -> [-3.21267, 0.0927343, 1.51819]

Camera #5 center: [-3.7607, 0.167619, 2.16665] -> [-3.70987, 0.149199, 2.21198]

Camera #6 center: [-3.99627, 0.258469, 2.9746] -> [-3.91765, 0.233673, 3.01476]

Camera #7 center: [-4.15915, 0.350085, 3.80086] -> [-4.05008, 0.32002, 3.88292]

Camera #8 center: [-3.84801, 0.276372, 4.86567] -> [-3.7396, 0.415642, 4.94726]

After BA tie poits: 47% old + 5% new = 53% total outliers

After BA projections: 45% inliers with MSE=0.200532

    Camera #0 projections: 53% inliers (713/1358) with MSE=0.299358

    Camera #1 projections: 57% inliers (1043/1846) with MSE=0.277011

    Camera #2 projections: 40% inliers (990/2484) with MSE=0.104328

    Camera #3 projections: 35% inliers (893/2543) with MSE=0.181952

    Camera #4 projections: 30% inliers (894/2976) with MSE=0.203606

    Camera #5 projections: 31% inliers (949/3036) with MSE=0.359275

    Camera #6 projections: 38% inliers (1224/3221) with MSE=0.144066

    Camera #7 projections: 59% inliers (1489/2512) with MSE=0.165115

    Camera #8 projections: 87% inliers (1535/1773) with MSE=0.154968

Append camera #9 (IMG_3032.JPG) to alignment via 841 common points

Before BA camera: k1=-7.1155e-08, k2=-1.42973e-14, f=1687.64, cx=320.66, cy=520.061

Before BA projections: 40% inliers with MSE=0.305341

    Camera #0 projections: 53% inliers (713/1358) with MSE=0.299358

    Camera #1 projections: 57% inliers (1043/1846) with MSE=0.277011

    Camera #2 projections: 40% inliers (990/2484) with MSE=0.104328

    Camera #3 projections: 35% inliers (893/2543) with MSE=0.181952

    Camera #4 projections: 30% inliers (894/2980) with MSE=0.203606

    Camera #5 projections: 31% inliers (956/3051) with MSE=0.369361

    Camera #6 projections: 38% inliers (1234/3249) with MSE=0.15182

    Camera #7 projections: 57% inliers (1504/2657) with MSE=0.183025

    Camera #8 projections: 61% inliers (1662/2719) with MSE=0.317985

    Camera #9 projections: 9% inliers (185/2025) with MSE=4.22504

After BA camera: k1=-2.73905e-08, k2=-1.33329e-13, f=1687.58, cx=326.003, cy=525.049

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85487, 0.0223696, 0.521142] -> [-1.85426, 0.0210326, 0.518578]

Camera #3 center: [-2.64111, 0.0452635, 0.944877] -> [-2.64028, 0.0425519, 0.941442]

Camera #4 center: [-3.21267, 0.0927343, 1.51819] -> [-3.21438, 0.0878218, 1.51609]

Camera #5 center: [-3.70987, 0.149199, 2.21198] -> [-3.71149, 0.142422, 2.2136]

Camera #6 center: [-3.91765, 0.233673, 3.01476] -> [-3.9184, 0.224249, 3.02153]

Camera #7 center: [-4.05008, 0.32002, 3.88292] -> [-4.04733, 0.307487, 3.88639]

Camera #8 center: [-3.7396, 0.415642, 4.94726] -> [-3.74878, 0.394129, 4.90524]

Camera #9 center: [-3.12124, 0.358799, 5.85886] -> [-3.36274, 0.451975, 5.81179]

After BA tie poits: 46% old + 4% new = 50% total outliers

After BA projections: 45% inliers with MSE=0.163839

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.295067

    Camera #1 projections: 55% inliers (1013/1846) with MSE=0.21281

    Camera #2 projections: 40% inliers (987/2484) with MSE=0.0976997

    Camera #3 projections: 35% inliers (885/2543) with MSE=0.190389

    Camera #4 projections: 28% inliers (842/2980) with MSE=0.177537

    Camera #5 projections: 27% inliers (819/3051) with MSE=0.265071

    Camera #6 projections: 30% inliers (976/3249) with MSE=0.143012

    Camera #7 projections: 48% inliers (1272/2657) with MSE=0.135385

    Camera #8 projections: 71% inliers (1923/2719) with MSE=0.119671

    Camera #9 projections: 92% inliers (1858/2025) with MSE=0.134787

Append camera #10 (IMG_3033.JPG) to alignment via 848 common points

Before BA camera: k1=-2.73905e-08, k2=-1.33329e-13, f=1687.58, cx=326.003, cy=525.049

Before BA projections: 41% inliers with MSE=0.185239

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.295067

    Camera #1 projections: 55% inliers (1013/1846) with MSE=0.21281

    Camera #2 projections: 40% inliers (987/2484) with MSE=0.0976997

    Camera #3 projections: 35% inliers (885/2543) with MSE=0.190389

    Camera #4 projections: 28% inliers (842/2988) with MSE=0.177537

    Camera #5 projections: 27% inliers (819/3065) with MSE=0.265071

    Camera #6 projections: 30% inliers (976/3265) with MSE=0.143012

    Camera #7 projections: 48% inliers (1273/2672) with MSE=0.138075

    Camera #8 projections: 69% inliers (1923/2783) with MSE=0.119671

    Camera #9 projections: 67% inliers (1860/2770) with MSE=0.138936

    Camera #10 projections: 6% inliers (99/1751) with MSE=2.51353

After BA camera: k1=-3.7414e-08, k2=-1.01486e-13, f=1679.67, cx=327.735, cy=527.432

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85426, 0.0210326, 0.518578] -> [-1.85344, 0.0204748, 0.51691]

Camera #3 center: [-2.64028, 0.0425519, 0.941442] -> [-2.639, 0.0412086, 0.937318]

Camera #4 center: [-3.21438, 0.0878218, 1.51609] -> [-3.21291, 0.0856669, 1.50894]

Camera #5 center: [-3.71149, 0.142422, 2.2136] -> [-3.71123, 0.138761, 2.20129]

Camera #6 center: [-3.9184, 0.224249, 3.02153] -> [-3.92143, 0.220485, 3.00627]

Camera #7 center: [-4.04733, 0.307487, 3.88639] -> [-4.0536, 0.304755, 3.88893]

Camera #8 center: [-3.74878, 0.394129, 4.90524] -> [-3.76235, 0.38855, 4.87801]

Camera #9 center: [-3.36274, 0.451975, 5.81179] -> [-3.39277, 0.445517, 5.77571]

Camera #10 center: [-2.6643, 0.208942, 6.8643] -> [-2.69882, 0.518033, 6.51464]

After BA tie poits: 46% old + 4% new = 50% total outliers

After BA projections: 49% inliers with MSE=0.285539

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.306

    Camera #1 projections: 55% inliers (1014/1846) with MSE=0.224223

    Camera #2 projections: 40% inliers (989/2484) with MSE=0.110719

    Camera #3 projections: 34% inliers (867/2543) with MSE=0.154862

    Camera #4 projections: 28% inliers (834/2988) with MSE=0.217901

    Camera #5 projections: 26% inliers (796/3065) with MSE=0.382756

    Camera #6 projections: 29% inliers (944/3265) with MSE=0.375841

    Camera #7 projections: 46% inliers (1237/2672) with MSE=0.504781

    Camera #8 projections: 69% inliers (1914/2783) with MSE=0.235956

    Camera #9 projections: 90% inliers (2498/2770) with MSE=0.393314

    Camera #10 projections: 91% inliers (1602/1751) with MSE=0.14952

Append camera #11 (IMG_3034.JPG) to alignment via 572 common points

Before BA camera: k1=-3.7414e-08, k2=-1.01486e-13, f=1679.67, cx=327.735, cy=527.432

Before BA projections: 47% inliers with MSE=0.339277

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.306

    Camera #1 projections: 55% inliers (1014/1846) with MSE=0.224223

    Camera #2 projections: 40% inliers (989/2484) with MSE=0.110719

    Camera #3 projections: 34% inliers (867/2543) with MSE=0.154862

    Camera #4 projections: 28% inliers (834/2991) with MSE=0.217901

    Camera #5 projections: 26% inliers (796/3070) with MSE=0.382756

    Camera #6 projections: 29% inliers (944/3268) with MSE=0.375841

    Camera #7 projections: 46% inliers (1237/2674) with MSE=0.504781

    Camera #8 projections: 69% inliers (1916/2791) with MSE=0.239308

    Camera #9 projections: 87% inliers (2500/2866) with MSE=0.397116

    Camera #10 projections: 73% inliers (1715/2365) with MSE=0.215613

    Camera #11 projections: 28% inliers (379/1333) with MSE=1.95571

After BA camera: k1=-3.61661e-08, k2=-1.03242e-13, f=1692.8, cx=327.881, cy=526.028

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85344, 0.0204748, 0.51691] -> [-1.85272, 0.0202245, 0.516671]

Camera #3 center: [-2.639, 0.0412086, 0.937318] -> [-2.635, 0.0405213, 0.934624]

Camera #4 center: [-3.21291, 0.0856669, 1.50894] -> [-3.20692, 0.0839222, 1.5022]

Camera #5 center: [-3.71123, 0.138761, 2.20129] -> [-3.70804, 0.137009, 2.19548]

Camera #6 center: [-3.92143, 0.220485, 3.00627] -> [-3.91912, 0.21878, 3.0017]

Camera #7 center: [-4.0536, 0.304755, 3.88893] -> [-4.05159, 0.303418, 3.88983]

Camera #8 center: [-3.76235, 0.38855, 4.87801] -> [-3.75641, 0.388573, 4.88794]

Camera #9 center: [-3.39277, 0.445517, 5.77571] -> [-3.38527, 0.445216, 5.77963]

Camera #10 center: [-2.69882, 0.518033, 6.51464] -> [-2.69158, 0.518075, 6.51291]

Camera #11 center: [-2.08039, 0.487207, 6.96671] -> [-2.02842, 0.569152, 7.00171]

After BA tie poits: 46% old + 3% new = 49% total outliers

After BA projections: 48% inliers with MSE=0.430383

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.30567

    Camera #1 projections: 55% inliers (1011/1846) with MSE=0.211073

    Camera #2 projections: 40% inliers (989/2484) with MSE=0.106753

    Camera #3 projections: 34% inliers (863/2543) with MSE=0.152281

    Camera #4 projections: 28% inliers (848/2991) with MSE=0.291736

    Camera #5 projections: 27% inliers (822/3070) with MSE=0.533125

    Camera #6 projections: 29% inliers (949/3268) with MSE=0.448756

    Camera #7 projections: 45% inliers (1207/2674) with MSE=0.797602

    Camera #8 projections: 59% inliers (1649/2791) with MSE=0.608184

    Camera #9 projections: 69% inliers (1968/2866) with MSE=0.489609

    Camera #10 projections: 80% inliers (1892/2365) with MSE=0.605468

    Camera #11 projections: 87% inliers (1161/1333) with MSE=0.173518

Append camera #12 (IMG_3035.JPG) to alignment via 311 common points

Before BA camera: k1=-3.61661e-08, k2=-1.03242e-13, f=1692.8, cx=327.881, cy=526.028

Before BA projections: 49% inliers with MSE=0.665726

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.30567

    Camera #1 projections: 55% inliers (1011/1846) with MSE=0.211073

    Camera #2 projections: 40% inliers (989/2484) with MSE=0.106753

    Camera #3 projections: 34% inliers (863/2543) with MSE=0.152281

    Camera #4 projections: 28% inliers (848/2991) with MSE=0.291736

    Camera #5 projections: 27% inliers (822/3070) with MSE=0.533125

    Camera #6 projections: 29% inliers (949/3268) with MSE=0.448756

    Camera #7 projections: 45% inliers (1207/2674) with MSE=0.797602

    Camera #8 projections: 59% inliers (1649/2791) with MSE=0.608184

    Camera #9 projections: 69% inliers (1968/2866) with MSE=0.489609

    Camera #10 projections: 74% inliers (1981/2687) with MSE=0.758102

    Camera #11 projections: 82% inliers (1854/2274) with MSE=0.942381

    Camera #12 projections: 74% inliers (1237/1670) with MSE=2.22567

After BA camera: k1=-4.09259e-08, k2=-7.38368e-14, f=1626.46, cx=336.751, cy=542.994

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85272, 0.0202245, 0.516671] -> [-1.85231, 0.0178137, 0.509477]

Camera #3 center: [-2.635, 0.0405213, 0.934624] -> [-2.63826, 0.0351809, 0.920837]

Camera #4 center: [-3.20692, 0.0839222, 1.5022] -> [-3.21502, 0.0749767, 1.48304]

Camera #5 center: [-3.70804, 0.137009, 2.19548] -> [-3.72399, 0.12407, 2.1731]

Camera #6 center: [-3.91912, 0.21878, 3.0017] -> [-3.94391, 0.200943, 2.97838]

Camera #7 center: [-4.05159, 0.303418, 3.88983] -> [-4.08705, 0.280562, 3.85497]

Camera #8 center: [-3.75641, 0.388573, 4.88794] -> [-3.80607, 0.360338, 4.86009]

Camera #9 center: [-3.38527, 0.445216, 5.77963] -> [-3.4466, 0.413968, 5.76195]

Camera #10 center: [-2.69158, 0.518075, 6.51291] -> [-2.77079, 0.482787, 6.49838]

Camera #11 center: [-2.02842, 0.569152, 7.00171] -> [-2.13311, 0.530148, 6.9901]

Camera #12 center: [-1.23931, 0.631229, 7.44961] -> [-1.37655, 0.58772, 7.43633]

After BA tie poits: 44% old + 6% new = 50% total outliers

After BA projections: 45% inliers with MSE=0.168884

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.377661

    Camera #1 projections: 55% inliers (1019/1846) with MSE=0.268997

    Camera #2 projections: 40% inliers (984/2484) with MSE=0.0968536

    Camera #3 projections: 33% inliers (842/2543) with MSE=0.0777478

    Camera #4 projections: 27% inliers (803/2991) with MSE=0.178563

    Camera #5 projections: 23% inliers (717/3070) with MSE=0.215248

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 717 vs 767.5

Append camera #13 (IMG_3036.JPG) to alignment via 389 common points

Before BA camera: k1=-4.09259e-08, k2=-7.38368e-14, f=1626.46, cx=336.751, cy=542.994

Before BA projections: 44% inliers with MSE=0.277196

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.377661

    Camera #1 projections: 55% inliers (1019/1846) with MSE=0.268997

    Camera #2 projections: 40% inliers (984/2484) with MSE=0.0968536

    Camera #3 projections: 33% inliers (842/2543) with MSE=0.0777478

    Camera #4 projections: 27% inliers (803/2991) with MSE=0.178563

    Camera #5 projections: 23% inliers (717/3070) with MSE=0.215248

    Camera #6 projections: 24% inliers (782/3268) with MSE=0.130662

    Camera #7 projections: 34% inliers (909/2674) with MSE=0.132595

    Camera #8 projections: 49% inliers (1370/2791) with MSE=0.111699

    Camera #9 projections: 59% inliers (1678/2867) with MSE=0.236185

    Camera #10 projections: 64% inliers (1723/2687) with MSE=0.197197

    Camera #11 projections: 69% inliers (1743/2529) with MSE=0.141706

    Camera #12 projections: 73% inliers (1732/2388) with MSE=0.434801

    Camera #13 projections: 26% inliers (391/1484) with MSE=2.95915

After BA camera: k1=-4.97103e-08, k2=-5.56281e-14, f=1586.97, cx=337.012, cy=544.702

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85231, 0.0178137, 0.509477] -> [-1.85454, 0.0184539, 0.50721]

Camera #3 center: [-2.63826, 0.0351809, 0.920837] -> [-2.64422, 0.0366406, 0.914975]

Camera #4 center: [-3.21502, 0.0749767, 1.48304] -> [-3.2248, 0.0778069, 1.47352]

Camera #5 center: [-3.72399, 0.12407, 2.1731] -> [-3.74072, 0.128782, 2.16112]

Camera #6 center: [-3.94391, 0.200943, 2.97838] -> [-3.96851, 0.207713, 2.96843]

Camera #7 center: [-4.08705, 0.280562, 3.85497] -> [-4.1204, 0.29032, 3.84604]

Camera #8 center: [-3.80607, 0.360338, 4.86009] -> [-3.84873, 0.372625, 4.85617]

Camera #9 center: [-3.4466, 0.413968, 5.76195] -> [-3.50227, 0.429109, 5.75961]

Camera #10 center: [-2.77079, 0.482787, 6.49838] -> [-2.83351, 0.500784, 6.50923]

Camera #11 center: [-2.13311, 0.530148, 6.9901] -> [-2.19958, 0.550859, 7.01351]

Camera #12 center: [-1.37655, 0.58772, 7.43633] -> [-1.43104, 0.613269, 7.47788]

Camera #13 center: [-0.55916, 0.55364, 7.68842] -> [-0.611506, 0.624497, 7.72291]

After BA tie poits: 46% old + 6% new = 52% total outliers

After BA projections: 44% inliers with MSE=0.20445

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.395863

    Camera #1 projections: 59% inliers (1090/1846) with MSE=0.545091

    Camera #2 projections: 40% inliers (985/2484) with MSE=0.0947709

    Camera #3 projections: 33% inliers (849/2543) with MSE=0.109855

    Camera #4 projections: 27% inliers (799/2991) with MSE=0.162919

    Camera #5 projections: 24% inliers (731/3070) with MSE=0.332609

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 731 vs 767.5

Append camera #14 (IMG_3037.JPG) to alignment via 614 common points

Before BA camera: k1=-4.97103e-08, k2=-5.56281e-14, f=1586.97, cx=337.012, cy=544.702

Before BA projections: 44% inliers with MSE=0.295694

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.395863

    Camera #1 projections: 59% inliers (1090/1846) with MSE=0.545091

    Camera #2 projections: 40% inliers (985/2484) with MSE=0.0947709

    Camera #3 projections: 33% inliers (849/2543) with MSE=0.109855

    Camera #4 projections: 27% inliers (799/2991) with MSE=0.162919

    Camera #5 projections: 24% inliers (731/3070) with MSE=0.332609

    Camera #6 projections: 24% inliers (777/3268) with MSE=0.123315

    Camera #7 projections: 34% inliers (900/2674) with MSE=0.121042

    Camera #8 projections: 48% inliers (1353/2791) with MSE=0.123343

    Camera #9 projections: 55% inliers (1587/2867) with MSE=0.167321

    Camera #10 projections: 60% inliers (1615/2687) with MSE=0.190497

    Camera #11 projections: 52% inliers (1328/2546) with MSE=0.208406

    Camera #12 projections: 62% inliers (1523/2449) with MSE=0.259144

    Camera #13 projections: 76% inliers (1540/2027) with MSE=0.65719

    Camera #14 projections: 24% inliers (302/1249) with MSE=2.29783

After BA camera: k1=-4.40375e-08, k2=-7.68094e-14, f=1667.81, cx=332.718, cy=535.178

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85454, 0.0184539, 0.50721] -> [-1.85167, 0.0188063, 0.513349]

Camera #3 center: [-2.64422, 0.0366406, 0.914975] -> [-2.63592, 0.0374102, 0.929604]

Camera #4 center: [-3.2248, 0.0778069, 1.47352] -> [-3.2097, 0.0788509, 1.49642]

Camera #5 center: [-3.74072, 0.128782, 2.16112] -> [-3.71275, 0.129615, 2.19015]

Camera #6 center: [-3.96851, 0.207713, 2.96843] -> [-3.92541, 0.208142, 2.99465]

Camera #7 center: [-4.1204, 0.29032, 3.84604] -> [-4.06071, 0.288867, 3.86883]

Camera #8 center: [-3.84873, 0.372625, 4.85617] -> [-3.77146, 0.370224, 4.86899]

Camera #9 center: [-3.50227, 0.429109, 5.75961] -> [-3.40314, 0.424639, 5.76787]

Camera #10 center: [-2.83351, 0.500784, 6.50923] -> [-2.71159, 0.494819, 6.50441]

Camera #11 center: [-2.19958, 0.550859, 7.01351] -> [-2.06552, 0.543068, 6.98745]

Camera #12 center: [-1.43104, 0.613269, 7.47788] -> [-1.29341, 0.598983, 7.42619]

Camera #13 center: [-0.611506, 0.624497, 7.72291] -> [-0.439545, 0.608084, 7.642]

Camera #14 center: [0.153661, 0.609443, 8.03117] -> [0.32848, 0.62483, 7.75007]

After BA tie poits: 49% old + 2% new = 51% total outliers

After BA projections: 42% inliers with MSE=0.148194

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.336671

    Camera #1 projections: 55% inliers (1008/1846) with MSE=0.221893

    Camera #2 projections: 40% inliers (987/2484) with MSE=0.109737

    Camera #3 projections: 34% inliers (864/2543) with MSE=0.140481

    Camera #4 projections: 26% inliers (790/2991) with MSE=0.159473

    Camera #5 projections: 24% inliers (725/3070) with MSE=0.256911

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 725 vs 767.5

Append camera #15 (IMG_3038.JPG) to alignment via 822 common points

Before BA camera: k1=-4.40375e-08, k2=-7.68094e-14, f=1667.81, cx=332.718, cy=535.178

Before BA projections: 42% inliers with MSE=0.346681

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.336671

    Camera #1 projections: 55% inliers (1008/1846) with MSE=0.221893

    Camera #2 projections: 40% inliers (987/2484) with MSE=0.109737

    Camera #3 projections: 34% inliers (864/2543) with MSE=0.140481

    Camera #4 projections: 26% inliers (790/2991) with MSE=0.159473

    Camera #5 projections: 24% inliers (725/3070) with MSE=0.256911

    Camera #6 projections: 24% inliers (779/3268) with MSE=0.142276

    Camera #7 projections: 34% inliers (901/2674) with MSE=0.12805

    Camera #8 projections: 47% inliers (1323/2791) with MSE=0.0837052

    Camera #9 projections: 54% inliers (1561/2867) with MSE=0.121492

    Camera #10 projections: 50% inliers (1355/2687) with MSE=0.158865

    Camera #11 projections: 39% inliers (995/2564) with MSE=0.251067

    Camera #12 projections: 46% inliers (1123/2467) with MSE=0.136299

    Camera #13 projections: 54% inliers (1276/2353) with MSE=0.139168

    Camera #14 projections: 74% inliers (1454/1965) with MSE=0.404403

    Camera #15 projections: 52% inliers (1006/1951) with MSE=2.91159

After BA camera: k1=-5.52124e-08, k2=-3.45381e-14, f=1670.92, cx=333.033, cy=536.006

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85167, 0.0188063, 0.513349] -> [-1.85097, 0.0184166, 0.513647]

Camera #3 center: [-2.63592, 0.0374102, 0.929604] -> [-2.63433, 0.03661, 0.930491]

Camera #4 center: [-3.2097, 0.0788509, 1.49642] -> [-3.20673, 0.077468, 1.49757]

Camera #5 center: [-3.71275, 0.129615, 2.19015] -> [-3.70824, 0.127379, 2.19097]

Camera #6 center: [-3.92541, 0.208142, 2.99465] -> [-3.91912, 0.204885, 2.99345]

Camera #7 center: [-4.06071, 0.288867, 3.86883] -> [-4.05328, 0.284416, 3.86469]

Camera #8 center: [-3.77146, 0.370224, 4.86899] -> [-3.76371, 0.364812, 4.86376]

Camera #9 center: [-3.40314, 0.424639, 5.76787] -> [-3.39388, 0.418444, 5.76291]

Camera #10 center: [-2.71159, 0.494819, 6.50441] -> [-2.70139, 0.487859, 6.49803]

Camera #11 center: [-2.06552, 0.543068, 6.98745] -> [-2.05078, 0.536032, 6.9818]

Camera #12 center: [-1.29341, 0.598983, 7.42619] -> [-1.27333, 0.591422, 7.41773]

Camera #13 center: [-0.439545, 0.608084, 7.642] -> [-0.434762, 0.599102, 7.62806]

Camera #14 center: [0.32848, 0.62483, 7.75007] -> [0.342007, 0.615921, 7.7315]

Camera #15 center: [1.11174, 0.591155, 7.61436] -> [1.12288, 0.600296, 7.60814]

After BA tie poits: 47% old + 2% new = 50% total outliers

After BA projections: 44% inliers with MSE=0.197021

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.341785

    Camera #1 projections: 55% inliers (1008/1846) with MSE=0.224642

    Camera #2 projections: 40% inliers (985/2484) with MSE=0.0972125

    Camera #3 projections: 34% inliers (856/2543) with MSE=0.125022

    Camera #4 projections: 26% inliers (789/2991) with MSE=0.140018

    Camera #5 projections: 23% inliers (712/3070) with MSE=0.189297

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 712 vs 767.5

Append camera #16 (IMG_3039.JPG) to alignment via 879 common points

Before BA camera: k1=-5.52124e-08, k2=-3.45381e-14, f=1670.92, cx=333.033, cy=536.006

Before BA projections: 44% inliers with MSE=0.320059

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.341785

    Camera #1 projections: 55% inliers (1008/1846) with MSE=0.224642

    Camera #2 projections: 40% inliers (985/2484) with MSE=0.0972125

    Camera #3 projections: 34% inliers (856/2543) with MSE=0.125022

    Camera #4 projections: 26% inliers (789/2991) with MSE=0.140018

    Camera #5 projections: 23% inliers (712/3070) with MSE=0.189297

    Camera #6 projections: 24% inliers (781/3268) with MSE=0.145422

    Camera #7 projections: 34% inliers (897/2674) with MSE=0.107183

    Camera #8 projections: 47% inliers (1317/2791) with MSE=0.0820249

    Camera #9 projections: 54% inliers (1539/2867) with MSE=0.105038

    Camera #10 projections: 50% inliers (1346/2687) with MSE=0.154564

    Camera #11 projections: 37% inliers (938/2569) with MSE=0.243737

    Camera #12 projections: 40% inliers (990/2478) with MSE=0.351611

    Camera #13 projections: 58% inliers (1383/2382) with MSE=0.303505

    Camera #14 projections: 76% inliers (1628/2150) with MSE=0.476363

    Camera #15 projections: 77% inliers (2034/2634) with MSE=0.419755

    Camera #16 projections: 39% inliers (718/1839) with MSE=2.4132

After BA camera: k1=-5.2869e-08, k2=-3.46615e-14, f=1647.45, cx=339.704, cy=544.151

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85097, 0.0184166, 0.513647] -> [-1.85037, 0.0167339, 0.508857]

Camera #3 center: [-2.63433, 0.03661, 0.930491] -> [-2.63457, 0.0327162, 0.920941]

Camera #4 center: [-3.20673, 0.077468, 1.49757] -> [-3.20907, 0.0707396, 1.48338]

Camera #5 center: [-3.70824, 0.127379, 2.19097] -> [-3.71429, 0.117431, 2.17234]

Camera #6 center: [-3.91912, 0.204885, 2.99345] -> [-3.93098, 0.19172, 2.97399]

Camera #7 center: [-4.05328, 0.284416, 3.86469] -> [-4.07123, 0.268101, 3.84462]

Camera #8 center: [-3.76371, 0.364812, 4.86376] -> [-3.78994, 0.344772, 4.84282]

Camera #9 center: [-3.39388, 0.418444, 5.76291] -> [-3.42839, 0.395718, 5.74355]

Camera #10 center: [-2.70139, 0.487859, 6.49803] -> [-2.74532, 0.463126, 6.48252]

Camera #11 center: [-2.05078, 0.536032, 6.9818] -> [-2.10253, 0.510257, 6.97084]

Camera #12 center: [-1.27333, 0.591422, 7.41773] -> [-1.33129, 0.565568, 7.41589]

Camera #13 center: [-0.434762, 0.599102, 7.62806] -> [-0.487436, 0.573748, 7.63638]

Camera #14 center: [0.342007, 0.615921, 7.7315] -> [0.266675, 0.591843, 7.74834]

Camera #15 center: [1.12288, 0.600296, 7.60814] -> [1.07267, 0.575703, 7.63254]

Camera #16 center: [1.93867, 0.438493, 7.36082] -> [1.85742, 0.55256, 7.33866]

After BA tie poits: 47% old + 2% new = 49% total outliers

After BA projections: 44% inliers with MSE=0.133175

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.394328

    Camera #1 projections: 55% inliers (1023/1846) with MSE=0.305056

    Camera #2 projections: 40% inliers (983/2484) with MSE=0.0938753

    Camera #3 projections: 33% inliers (843/2543) with MSE=0.0786372

    Camera #4 projections: 26% inliers (788/2991) with MSE=0.149633

    Camera #5 projections: 23% inliers (707/3070) with MSE=0.193336

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 707 vs 767.5

Append camera #17 (IMG_3040.JPG) to alignment via 803 common points

Before BA camera: k1=-5.2869e-08, k2=-3.46615e-14, f=1647.45, cx=339.704, cy=544.151

Before BA projections: 43% inliers with MSE=0.272421

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.394328

    Camera #1 projections: 55% inliers (1023/1846) with MSE=0.305056

    Camera #2 projections: 40% inliers (983/2484) with MSE=0.0938753

    Camera #3 projections: 33% inliers (843/2543) with MSE=0.0786372

    Camera #4 projections: 26% inliers (788/2991) with MSE=0.149633

    Camera #5 projections: 23% inliers (707/3070) with MSE=0.193336

    Camera #6 projections: 24% inliers (777/3268) with MSE=0.123961

    Camera #7 projections: 33% inliers (893/2674) with MSE=0.0963866

    Camera #8 projections: 47% inliers (1316/2791) with MSE=0.0745283

    Camera #9 projections: 53% inliers (1528/2867) with MSE=0.0830143

    Camera #10 projections: 49% inliers (1313/2687) with MSE=0.0927129

    Camera #11 projections: 34% inliers (869/2569) with MSE=0.134266

    Camera #12 projections: 34% inliers (855/2486) with MSE=0.12234

    Camera #13 projections: 46% inliers (1092/2396) with MSE=0.11721

    Camera #14 projections: 63% inliers (1360/2167) with MSE=0.130286

    Camera #15 projections: 67% inliers (1981/2935) with MSE=0.15588

    Camera #16 projections: 67% inliers (1942/2899) with MSE=0.441766

    Camera #17 projections: 43% inliers (968/2265) with MSE=2.27978

After BA camera: k1=-5.54701e-08, k2=5.32511e-15, f=1610.16, cx=347.021, cy=556.515

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85037, 0.0167339, 0.508857] -> [-1.85041, 0.0143289, 0.503441]

Camera #3 center: [-2.63457, 0.0327162, 0.920941] -> [-2.63549, 0.0273198, 0.909971]

Camera #4 center: [-3.20907, 0.0707396, 1.48338] -> [-3.21246, 0.061179, 1.46667]

Camera #5 center: [-3.71429, 0.117431, 2.17234] -> [-3.72245, 0.102965, 2.14995]

Camera #6 center: [-3.93098, 0.19172, 2.97399] -> [-3.94685, 0.172114, 2.95064]

Camera #7 center: [-4.07123, 0.268101, 3.84462] -> [-4.09512, 0.243387, 3.81961]

Camera #8 center: [-3.78994, 0.344772, 4.84282] -> [-3.82558, 0.314023, 4.81654]

Camera #9 center: [-3.42839, 0.395718, 5.74355] -> [-3.47514, 0.360527, 5.72034]

Camera #10 center: [-2.74532, 0.463126, 6.48252] -> [-2.80499, 0.424217, 6.46494]

Camera #11 center: [-2.10253, 0.510257, 6.97084] -> [-2.17064, 0.469598, 6.96152]

Camera #12 center: [-1.33129, 0.565568, 7.41589] -> [-1.41448, 0.522608, 7.4153]

Camera #13 center: [-0.487436, 0.573748, 7.63638] -> [-0.596357, 0.530845, 7.64771]

Camera #14 center: [0.266675, 0.591843, 7.74834] -> [0.154756, 0.549949, 7.77783]

Camera #15 center: [1.07267, 0.575703, 7.63254] -> [0.961715, 0.536063, 7.68152]

Camera #16 center: [1.85742, 0.55256, 7.33866] -> [1.75009, 0.517553, 7.40464]

Camera #17 center: [2.55699, 0.438249, 6.81216] -> [2.45444, 0.467299, 6.88506]

After BA tie poits: 45% old + 2% new = 47% total outliers

After BA projections: 45% inliers with MSE=0.127198

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.483104

    Camera #1 projections: 55% inliers (1008/1846) with MSE=0.298045

    Camera #2 projections: 40% inliers (983/2484) with MSE=0.0978573

    Camera #3 projections: 33% inliers (841/2543) with MSE=0.077477

    Camera #4 projections: 26% inliers (780/2991) with MSE=0.112945

    Camera #5 projections: 23% inliers (705/3070) with MSE=0.171157

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 705 vs 767.5

Append camera #18 (IMG_3041.JPG) to alignment via 903 common points

Before BA camera: k1=-5.54701e-08, k2=5.32511e-15, f=1610.16, cx=347.021, cy=556.515

Before BA projections: 45% inliers with MSE=0.29787

    Camera #0 projections: 52% inliers (710/1358) with MSE=0.483104

    Camera #1 projections: 55% inliers (1008/1846) with MSE=0.298045

    Camera #2 projections: 40% inliers (983/2484) with MSE=0.0978573

    Camera #3 projections: 33% inliers (841/2543) with MSE=0.077477

    Camera #4 projections: 26% inliers (780/2991) with MSE=0.112945

    Camera #5 projections: 23% inliers (705/3070) with MSE=0.171157

    Camera #6 projections: 24% inliers (776/3268) with MSE=0.110991

    Camera #7 projections: 33% inliers (892/2674) with MSE=0.0880424

    Camera #8 projections: 47% inliers (1315/2791) with MSE=0.0660283

    Camera #9 projections: 53% inliers (1528/2867) with MSE=0.0798177

    Camera #10 projections: 49% inliers (1305/2687) with MSE=0.0872666

    Camera #11 projections: 33% inliers (848/2569) with MSE=0.117586

    Camera #12 projections: 33% inliers (808/2486) with MSE=0.124564

    Camera #13 projections: 40% inliers (966/2401) with MSE=0.0937617

    Camera #14 projections: 50% inliers (1095/2176) with MSE=0.107932

    Camera #15 projections: 65% inliers (1913/2953) with MSE=0.0983361

    Camera #16 projections: 68% inliers (2306/3384) with MSE=0.368723

    Camera #17 projections: 79% inliers (2570/3238) with MSE=0.362228

    Camera #18 projections: 52% inliers (1336/2550) with MSE=2.15408

After BA camera: k1=-8.66605e-08, k2=6.63054e-14, f=1516.5, cx=357.625, cy=577.336

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85041, 0.0143289, 0.503441] -> [-1.8541, 0.0124618, 0.48997]

Camera #3 center: [-2.63549, 0.0273198, 0.909971] -> [-2.64911, 0.0230872, 0.882195]

Camera #4 center: [-3.21246, 0.061179, 1.46667] -> [-3.23773, 0.0540199, 1.42367]

Camera #5 center: [-3.72245, 0.102965, 2.14995] -> [-3.76748, 0.092645, 2.09533]

Camera #6 center: [-3.94685, 0.172114, 2.95064] -> [-4.01811, 0.158012, 2.89766]

Camera #7 center: [-4.09512, 0.243387, 3.81961] -> [-4.19365, 0.226669, 3.76317]

Camera #8 center: [-3.82558, 0.314023, 4.81654] -> [-3.95616, 0.292438, 4.7742]

Camera #9 center: [-3.47514, 0.360527, 5.72034] -> [-3.63728, 0.337007, 5.69659]

Camera #10 center: [-2.80499, 0.424217, 6.46494] -> [-2.99317, 0.39873, 6.47201]

Camera #11 center: [-2.17064, 0.469598, 6.96152] -> [-2.37561, 0.444141, 6.9987]

Camera #12 center: [-1.41448, 0.522608, 7.4153] -> [-1.63329, 0.499137, 7.48985]

Camera #13 center: [-0.596357, 0.530845, 7.64771] -> [-0.803802, 0.511398, 7.76435]

Camera #14 center: [0.154756, 0.549949, 7.77783] -> [-0.0493189, 0.534461, 7.92568]

Camera #15 center: [0.961715, 0.536063, 7.68152] -> [0.735628, 0.527224, 7.86835]

Camera #16 center: [1.75009, 0.517553, 7.40464] -> [1.5113, 0.515014, 7.6487]

Camera #17 center: [2.45444, 0.467299, 6.88506] -> [2.2151, 0.472875, 7.19164]

Camera #18 center: [3.02033, 0.426324, 6.27267] -> [2.77118, 0.442372, 6.6237]

After BA tie poits: 44% old + 17% new = 60% total outliers

After BA projections: 45% inliers with MSE=0.141737

    Camera #0 projections: 52% inliers (708/1358) with MSE=0.660228

    Camera #1 projections: 55% inliers (1008/1846) with MSE=0.405597

    Camera #2 projections: 40% inliers (983/2484) with MSE=0.11666

    Camera #3 projections: 33% inliers (841/2543) with MSE=0.0851033

    Camera #4 projections: 26% inliers (780/2991) with MSE=0.117793

    Camera #5 projections: 23% inliers (702/3070) with MSE=0.148724

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 702 vs 767.5

Append camera #19 (IMG_3042.JPG) to alignment via 618 common points

Before BA camera: k1=-8.66605e-08, k2=6.63054e-14, f=1516.5, cx=357.625, cy=577.336

Before BA projections: 45% inliers with MSE=0.208857

    Camera #0 projections: 52% inliers (708/1358) with MSE=0.660228

    Camera #1 projections: 55% inliers (1008/1846) with MSE=0.405597

    Camera #2 projections: 40% inliers (983/2484) with MSE=0.11666

    Camera #3 projections: 33% inliers (841/2543) with MSE=0.0851033

    Camera #4 projections: 26% inliers (780/2991) with MSE=0.117793

    Camera #5 projections: 23% inliers (702/3070) with MSE=0.148724

    Camera #6 projections: 24% inliers (777/3268) with MSE=0.110844

    Camera #7 projections: 33% inliers (893/2674) with MSE=0.0989315

    Camera #8 projections: 47% inliers (1317/2791) with MSE=0.0759013

    Camera #9 projections: 54% inliers (1541/2867) with MSE=0.104815

    Camera #10 projections: 49% inliers (1315/2687) with MSE=0.107105

    Camera #11 projections: 33% inliers (843/2569) with MSE=0.119222

    Camera #12 projections: 32% inliers (793/2486) with MSE=0.113414

    Camera #13 projections: 38% inliers (919/2404) with MSE=0.115598

    Camera #14 projections: 45% inliers (986/2179) with MSE=0.0763529

    Camera #15 projections: 56% inliers (1662/2954) with MSE=0.0959579

    Camera #16 projections: 65% inliers (2220/3398) with MSE=0.132542

    Camera #17 projections: 69% inliers (2458/3568) with MSE=0.138473

    Camera #18 projections: 77% inliers (2340/3026) with MSE=0.358671

    Camera #19 projections: 58% inliers (861/1474) with MSE=1.34791

After BA camera: k1=-3.27352e-08, k2=-5.80844e-14, f=1634.34, cx=341.472, cy=548.447

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.8541, 0.0124618, 0.48997] -> [-1.85258, 0.0153544, 0.507263]

Camera #3 center: [-2.64911, 0.0230872, 0.882195] -> [-2.63801, 0.0299839, 0.91685]

Camera #4 center: [-3.23773, 0.0540199, 1.42367] -> [-3.21543, 0.065091, 1.4777]

Camera #5 center: [-3.76748, 0.092645, 2.09533] -> [-3.72458, 0.109223, 2.16522]

Camera #6 center: [-4.01811, 0.158012, 2.89766] -> [-3.94628, 0.181138, 2.97041]

Camera #7 center: [-4.19365, 0.226669, 3.76317] -> [-4.0909, 0.254609, 3.84668]

Camera #8 center: [-3.95616, 0.292438, 4.7742] -> [-3.81525, 0.327948, 4.8416]

Camera #9 center: [-3.63728, 0.337007, 5.69659] -> [-3.45732, 0.376556, 5.74871]

Camera #10 center: [-2.99317, 0.39873, 6.47201] -> [-2.788, 0.440064, 6.48395]

Camera #11 center: [-2.37561, 0.444141, 6.9987] -> [-2.14642, 0.487193, 6.98134]

Camera #12 center: [-1.63329, 0.499137, 7.48985] -> [-1.37885, 0.544793, 7.43327]

Camera #13 center: [-0.803802, 0.511398, 7.76435] -> [-0.537159, 0.551051, 7.66413]

Camera #14 center: [-0.0493189, 0.534461, 7.92568] -> [0.220519, 0.571011, 7.78389]

Camera #15 center: [0.735628, 0.527224, 7.86835] -> [1.01252, 0.555291, 7.68059]

Camera #16 center: [1.5113, 0.515014, 7.6487] -> [1.78894, 0.536196, 7.40562]

Camera #17 center: [2.2151, 0.472875, 7.19164] -> [2.48108, 0.484802, 6.88224]

Camera #18 center: [2.77118, 0.442372, 6.6237] -> [2.98714, 0.448333, 6.27025]

Camera #19 center: [3.32206, 0.385735, 6.06926] -> [3.46696, 0.421409, 5.67335]

After BA tie poits: 58% old + 1% new = 59% total outliers

After BA projections: 35% inliers with MSE=0.135091

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.415179

    Camera #1 projections: 56% inliers (1029/1846) with MSE=0.302816

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0916924

    Camera #3 projections: 32% inliers (802/2543) with MSE=0.0852695

    Camera #4 projections: 25% inliers (751/2991) with MSE=0.129336

    Camera #5 projections: 23% inliers (702/3070) with MSE=0.160018

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 702 vs 767.5

Append camera #20 (IMG_3043.JPG) to alignment via 474 common points

Before BA camera: k1=-3.27352e-08, k2=-5.80844e-14, f=1634.34, cx=341.472, cy=548.447

Before BA projections: 36% inliers with MSE=0.233091

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.415179

    Camera #1 projections: 56% inliers (1029/1846) with MSE=0.302816

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0916924

    Camera #3 projections: 32% inliers (802/2543) with MSE=0.0852695

    Camera #4 projections: 25% inliers (751/2991) with MSE=0.129336

    Camera #5 projections: 23% inliers (702/3070) with MSE=0.160018

    Camera #6 projections: 24% inliers (776/3268) with MSE=0.114501

    Camera #7 projections: 33% inliers (880/2674) with MSE=0.0894065

    Camera #8 projections: 39% inliers (1093/2791) with MSE=0.071931

    Camera #9 projections: 35% inliers (1011/2867) with MSE=0.0841284

    Camera #10 projections: 26% inliers (707/2687) with MSE=0.0859056

    Camera #11 projections: 28% inliers (712/2569) with MSE=0.111312

    Camera #12 projections: 21% inliers (515/2486) with MSE=0.252996

    Camera #13 projections: 30% inliers (718/2404) with MSE=0.16243

    Camera #14 projections: 32% inliers (701/2179) with MSE=0.218393

    Camera #15 projections: 36% inliers (1057/2954) with MSE=0.0784835

    Camera #16 projections: 34% inliers (1145/3401) with MSE=0.12041

    Camera #17 projections: 40% inliers (1449/3578) with MSE=0.101526

    Camera #18 projections: 45% inliers (1438/3169) with MSE=0.146982

    Camera #19 projections: 81% inliers (1647/2027) with MSE=0.443121

    Camera #20 projections: 59% inliers (718/1212) with MSE=1.94825

After BA camera: k1=-3.53889e-08, k2=-5.39122e-14, f=1630.59, cx=342.261, cy=549.34

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85258, 0.0153544, 0.507263] -> [-1.85005, 0.0156191, 0.507633]

Camera #3 center: [-2.63801, 0.0299839, 0.91685] -> [-2.63279, 0.0305549, 0.917835]

Camera #4 center: [-3.21543, 0.065091, 1.4777] -> [-3.20747, 0.0658593, 1.4785]

Camera #5 center: [-3.72458, 0.109223, 2.16522] -> [-3.71312, 0.110259, 2.16523]

Camera #6 center: [-3.94628, 0.181138, 2.97041] -> [-3.93168, 0.18206, 2.96724]

Camera #7 center: [-4.0909, 0.254609, 3.84668] -> [-4.07344, 0.255435, 3.84067]

Camera #8 center: [-3.81525, 0.327948, 4.8416] -> [-3.79612, 0.328405, 4.83105]

Camera #9 center: [-3.45732, 0.376556, 5.74871] -> [-3.43643, 0.376844, 5.73442]

Camera #10 center: [-2.788, 0.440064, 6.48395] -> [-2.76736, 0.439802, 6.46455]

Camera #11 center: [-2.14642, 0.487193, 6.98134] -> [-2.12631, 0.486548, 6.95795]

Camera #12 center: [-1.37885, 0.544793, 7.43327] -> [-1.35924, 0.543718, 7.40555]

Camera #13 center: [-0.537159, 0.551051, 7.66413] -> [-0.519571, 0.55, 7.63197]

Camera #14 center: [0.220519, 0.571011, 7.78389] -> [0.237227, 0.568629, 7.74838]

Camera #15 center: [1.01252, 0.555291, 7.68059] -> [1.02109, 0.554258, 7.64226]

Camera #16 center: [1.78894, 0.536196, 7.40562] -> [1.789, 0.534514, 7.36818]

Camera #17 center: [2.48108, 0.484802, 6.88224] -> [2.47402, 0.484481, 6.84748]

Camera #18 center: [2.98714, 0.448333, 6.27025] -> [2.98425, 0.447338, 6.22765]

Camera #19 center: [3.46696, 0.421409, 5.67335] -> [3.45908, 0.421589, 5.62777]

Camera #20 center: [3.95623, 0.359718, 5.02581] -> [3.93449, 0.380516, 5.01049]

After BA tie poits: 57% old + 2% new = 59% total outliers

After BA projections: 35% inliers with MSE=0.138315

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.417208

    Camera #1 projections: 56% inliers (1027/1846) with MSE=0.30677

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0934452

    Camera #3 projections: 32% inliers (803/2543) with MSE=0.0877198

    Camera #4 projections: 25% inliers (756/2991) with MSE=0.151521

    Camera #5 projections: 23% inliers (701/3070) with MSE=0.15376

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 701 vs 767.5

Append camera #21 (IMG_3044.JPG) to alignment via 488 common points

Before BA camera: k1=-3.53889e-08, k2=-5.39122e-14, f=1630.59, cx=342.261, cy=549.34

Before BA projections: 36% inliers with MSE=0.242231

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.417208

    Camera #1 projections: 56% inliers (1027/1846) with MSE=0.30677

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0934452

    Camera #3 projections: 32% inliers (803/2543) with MSE=0.0877198

    Camera #4 projections: 25% inliers (756/2991) with MSE=0.151521

    Camera #5 projections: 23% inliers (701/3070) with MSE=0.15376

    Camera #6 projections: 24% inliers (776/3268) with MSE=0.114422

    Camera #7 projections: 33% inliers (882/2674) with MSE=0.101692

    Camera #8 projections: 39% inliers (1094/2791) with MSE=0.0742249

    Camera #9 projections: 35% inliers (1011/2867) with MSE=0.083767

    Camera #10 projections: 26% inliers (706/2687) with MSE=0.0787687

    Camera #11 projections: 28% inliers (712/2569) with MSE=0.112219

    Camera #12 projections: 20% inliers (489/2486) with MSE=0.0946526

    Camera #13 projections: 29% inliers (702/2404) with MSE=0.119648

    Camera #14 projections: 31% inliers (673/2179) with MSE=0.159227

    Camera #15 projections: 35% inliers (1041/2954) with MSE=0.136369

    Camera #16 projections: 31% inliers (1069/3401) with MSE=0.120553

    Camera #17 projections: 35% inliers (1270/3582) with MSE=0.117479

    Camera #18 projections: 41% inliers (1306/3175) with MSE=0.13825

    Camera #19 projections: 74% inliers (1560/2104) with MSE=0.198554

    Camera #20 projections: 85% inliers (1394/1633) with MSE=0.569805

    Camera #21 projections: 81% inliers (820/1011) with MSE=1.88059

After BA camera: k1=-4.40512e-08, k2=-4.0031e-14, f=1640.13, cx=340.379, cy=547.088

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85005, 0.0156191, 0.507633] -> [-1.84986, 0.0161844, 0.508891]

Camera #3 center: [-2.63279, 0.0305549, 0.917835] -> [-2.63254, 0.0319033, 0.920659]

Camera #4 center: [-3.20747, 0.0658593, 1.4785] -> [-3.20629, 0.0682272, 1.48251]

Camera #5 center: [-3.71312, 0.110259, 2.16523] -> [-3.71069, 0.113826, 2.1707]

Camera #6 center: [-3.93168, 0.18206, 2.96724] -> [-3.92722, 0.186764, 2.97264]

Camera #7 center: [-4.07344, 0.255435, 3.84067] -> [-4.06693, 0.261309, 3.84658]

Camera #8 center: [-3.79612, 0.328405, 4.83105] -> [-3.78647, 0.335536, 4.83763]

Camera #9 center: [-3.43643, 0.376844, 5.73442] -> [-3.42382, 0.384897, 5.74007]

Camera #10 center: [-2.76736, 0.439802, 6.46455] -> [-2.75233, 0.448391, 6.46773]

Camera #11 center: [-2.12631, 0.486548, 6.95795] -> [-2.10942, 0.495411, 6.95898]

Camera #12 center: [-1.35924, 0.543718, 7.40555] -> [-1.34006, 0.552938, 7.40401]

Camera #13 center: [-0.519571, 0.55, 7.63197] -> [-0.499243, 0.558582, 7.62737]

Camera #14 center: [0.237227, 0.568629, 7.74838] -> [0.258517, 0.577839, 7.74033]

Camera #15 center: [1.02109, 0.554258, 7.64226] -> [1.03993, 0.561676, 7.63191]

Camera #16 center: [1.789, 0.534514, 7.36818] -> [1.80888, 0.541629, 7.35376]

Camera #17 center: [2.47402, 0.484481, 6.84748] -> [2.50602, 0.488756, 6.81775]

Camera #18 center: [2.98425, 0.447338, 6.22765] -> [3.00678, 0.450534, 6.19661]

Camera #19 center: [3.45908, 0.421589, 5.62777] -> [3.47784, 0.42338, 5.58826]

Camera #20 center: [3.93449, 0.380516, 5.01049] -> [3.95083, 0.380718, 4.94962]

Camera #21 center: [4.13991, 0.275787, 4.24057] -> [4.13547, 0.317548, 4.17336]

After BA tie poits: 57% old + 1% new = 58% total outliers

After BA projections: 35% inliers with MSE=0.145911

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.397186

    Camera #1 projections: 55% inliers (1017/1846) with MSE=0.290148

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0930489

    Camera #3 projections: 32% inliers (803/2543) with MSE=0.0891376

    Camera #4 projections: 25% inliers (751/2991) with MSE=0.14379

    Camera #5 projections: 23% inliers (700/3070) with MSE=0.151742

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 700 vs 767.5

Append camera #22 (IMG_3045.JPG) to alignment via 607 common points

Before BA camera: k1=-4.40512e-08, k2=-4.0031e-14, f=1640.13, cx=340.379, cy=547.088

Before BA projections: 36% inliers with MSE=0.235589

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.397186

    Camera #1 projections: 55% inliers (1017/1846) with MSE=0.290148

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0930489

    Camera #3 projections: 32% inliers (803/2543) with MSE=0.0891376

    Camera #4 projections: 25% inliers (751/2991) with MSE=0.14379

    Camera #5 projections: 23% inliers (700/3070) with MSE=0.151742

    Camera #6 projections: 24% inliers (776/3268) with MSE=0.11684

    Camera #7 projections: 33% inliers (882/2674) with MSE=0.0987897

    Camera #8 projections: 39% inliers (1094/2791) with MSE=0.078175

    Camera #9 projections: 35% inliers (1014/2867) with MSE=0.0895474

    Camera #10 projections: 26% inliers (706/2687) with MSE=0.0788871

    Camera #11 projections: 28% inliers (712/2569) with MSE=0.105695

    Camera #12 projections: 20% inliers (494/2486) with MSE=0.141671

    Camera #13 projections: 29% inliers (703/2404) with MSE=0.118398

    Camera #14 projections: 32% inliers (690/2179) with MSE=0.262907

    Camera #15 projections: 35% inliers (1031/2954) with MSE=0.144704

    Camera #16 projections: 31% inliers (1052/3401) with MSE=0.191113

    Camera #17 projections: 33% inliers (1188/3582) with MSE=0.106708

    Camera #18 projections: 37% inliers (1173/3175) with MSE=0.137661

    Camera #19 projections: 60% inliers (1278/2121) with MSE=0.171702

    Camera #20 projections: 68% inliers (1171/1719) with MSE=0.268063

    Camera #21 projections: 78% inliers (1118/1440) with MSE=0.574607

    Camera #22 projections: 49% inliers (578/1169) with MSE=2.19452

After BA camera: k1=-3.98704e-08, k2=-4.81378e-14, f=1644.36, cx=340.696, cy=546.929

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.84986, 0.0161844, 0.508891] -> [-1.84961, 0.0160062, 0.509019]

Camera #3 center: [-2.63254, 0.0319033, 0.920659] -> [-2.63174, 0.0314869, 0.921001]

Camera #4 center: [-3.20629, 0.0682272, 1.48251] -> [-3.20511, 0.0674499, 1.48317]

Camera #5 center: [-3.71069, 0.113826, 2.1707] -> [-3.70875, 0.112609, 2.17142]

Camera #6 center: [-3.92722, 0.186764, 2.97264] -> [-3.92454, 0.185118, 2.97319]

Camera #7 center: [-4.06693, 0.261309, 3.84658] -> [-4.06335, 0.259137, 3.84705]

Camera #8 center: [-3.78647, 0.335536, 4.83763] -> [-3.78211, 0.332895, 4.83713]

Camera #9 center: [-3.42382, 0.384897, 5.74007] -> [-3.41867, 0.381707, 5.73854]

Camera #10 center: [-2.75233, 0.448391, 6.46773] -> [-2.74659, 0.444823, 6.46512]

Camera #11 center: [-2.10942, 0.495411, 6.95898] -> [-2.10333, 0.491539, 6.95528]

Camera #12 center: [-1.34006, 0.552938, 7.40401] -> [-1.33356, 0.548658, 7.39899]

Camera #13 center: [-0.499243, 0.558582, 7.62737] -> [-0.492573, 0.554319, 7.62079]

Camera #14 center: [0.258517, 0.577839, 7.74033] -> [0.26487, 0.573038, 7.7325]

Camera #15 center: [1.03993, 0.561676, 7.63191] -> [1.04661, 0.557327, 7.62234]

Camera #16 center: [1.80888, 0.541629, 7.35376] -> [1.81503, 0.537066, 7.34232]

Camera #17 center: [2.50602, 0.488756, 6.81775] -> [2.50104, 0.485327, 6.81315]

Camera #18 center: [3.00678, 0.450534, 6.19661] -> [3.00854, 0.447268, 6.18423]

Camera #19 center: [3.47784, 0.42338, 5.58826] -> [3.4792, 0.420537, 5.57264]

Camera #20 center: [3.95083, 0.380718, 4.94962] -> [3.94684, 0.379106, 4.94948]

Camera #21 center: [4.13547, 0.317548, 4.17336] -> [4.13084, 0.317735, 4.18168]

Camera #22 center: [4.18689, 0.213694, 3.39385] -> [4.15917, 0.251551, 3.45038]

After BA tie poits: 57% old + 2% new = 59% total outliers

After BA projections: 36% inliers with MSE=0.200485

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.398645

    Camera #1 projections: 55% inliers (1015/1846) with MSE=0.2883

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.093242

    Camera #3 projections: 31% inliers (801/2543) with MSE=0.0792966

    Camera #4 projections: 25% inliers (747/2991) with MSE=0.118593

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 747 vs 747.75

Append camera #23 (IMG_3046.JPG) to alignment via 631 common points

Before BA camera: k1=-3.98704e-08, k2=-4.81378e-14, f=1644.36, cx=340.696, cy=546.929

Before BA projections: 37% inliers with MSE=0.323918

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.398645

    Camera #1 projections: 55% inliers (1015/1846) with MSE=0.2883

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.093242

    Camera #3 projections: 31% inliers (801/2543) with MSE=0.0792966

    Camera #4 projections: 25% inliers (747/2991) with MSE=0.118593

    Camera #5 projections: 23% inliers (701/3070) with MSE=0.159221

    Camera #6 projections: 24% inliers (776/3268) with MSE=0.116377

    Camera #7 projections: 33% inliers (881/2674) with MSE=0.0906082

    Camera #8 projections: 39% inliers (1094/2791) with MSE=0.0727764

    Camera #9 projections: 36% inliers (1021/2867) with MSE=0.103923

    Camera #10 projections: 26% inliers (706/2687) with MSE=0.0789859

    Camera #11 projections: 28% inliers (710/2569) with MSE=0.117431

    Camera #12 projections: 20% inliers (491/2486) with MSE=0.100961

    Camera #13 projections: 29% inliers (700/2404) with MSE=0.107331

    Camera #14 projections: 31% inliers (668/2179) with MSE=0.13128

    Camera #15 projections: 35% inliers (1032/2954) with MSE=0.149923

    Camera #16 projections: 30% inliers (1037/3401) with MSE=0.145459

    Camera #17 projections: 33% inliers (1183/3582) with MSE=0.116523

    Camera #18 projections: 37% inliers (1164/3175) with MSE=0.219472

    Camera #19 projections: 59% inliers (1245/2123) with MSE=0.390229

    Camera #20 projections: 64% inliers (1103/1737) with MSE=0.545965

    Camera #21 projections: 73% inliers (1193/1636) with MSE=0.681283

    Camera #22 projections: 75% inliers (1417/1894) with MSE=0.686763

    Camera #23 projections: 62% inliers (1018/1651) with MSE=2.00322

After BA camera: k1=-4.24116e-08, k2=-4.51124e-14, f=1644.31, cx=339.935, cy=546.166

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.84961, 0.0160062, 0.509019] -> [-1.8498, 0.0162861, 0.509344]

Camera #3 center: [-2.63174, 0.0314869, 0.921001] -> [-2.63224, 0.0321397, 0.921625]

Camera #4 center: [-3.20511, 0.0674499, 1.48317] -> [-3.20568, 0.068617, 1.48402]

Camera #5 center: [-3.70875, 0.112609, 2.17142] -> [-3.70946, 0.1144, 2.17267]

Camera #6 center: [-3.92454, 0.185118, 2.97319] -> [-3.92517, 0.187536, 2.97467]

Camera #7 center: [-4.06335, 0.259137, 3.84705] -> [-4.06395, 0.262246, 3.84879]

Camera #8 center: [-3.78211, 0.332895, 4.83713] -> [-3.78234, 0.336704, 4.83956]

Camera #9 center: [-3.41867, 0.381707, 5.73854] -> [-3.41856, 0.386171, 5.74143]

Camera #10 center: [-2.74659, 0.444823, 6.46512] -> [-2.74608, 0.449741, 6.46812]

Camera #11 center: [-2.10333, 0.491539, 6.95528] -> [-2.10245, 0.496781, 6.95839]

Camera #12 center: [-1.33356, 0.548658, 7.39899] -> [-1.33231, 0.554252, 7.40221]

Camera #13 center: [-0.492573, 0.554319, 7.62079] -> [-0.491006, 0.559958, 7.62407]

Camera #14 center: [0.26487, 0.573038, 7.7325] -> [0.266932, 0.578752, 7.73583]

Camera #15 center: [1.04661, 0.557327, 7.62234] -> [1.04897, 0.562873, 7.62565]

Camera #16 center: [1.81503, 0.537066, 7.34232] -> [1.81705, 0.542294, 7.34581]

Camera #17 center: [2.50104, 0.485327, 6.81315] -> [2.50377, 0.490012, 6.8164]

Camera #18 center: [3.00854, 0.447268, 6.18423] -> [3.01159, 0.451446, 6.18694]

Camera #19 center: [3.4792, 0.420537, 5.57264] -> [3.48215, 0.424329, 5.57628]

Camera #20 center: [3.94684, 0.379106, 4.94948] -> [3.95187, 0.38216, 4.94475]

Camera #21 center: [4.13084, 0.317735, 4.18168] -> [4.13328, 0.319551, 4.17392]

Camera #22 center: [4.15917, 0.251551, 3.45038] -> [4.16316, 0.255191, 3.45885]

Camera #23 center: [4.00799, 0.141527, 2.79805] -> [3.98137, 0.195438, 2.77877]

After BA tie poits: 56% old + 2% new = 58% total outliers

After BA projections: 39% inliers with MSE=0.278095

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.392189

    Camera #1 projections: 55% inliers (1010/1846) with MSE=0.263527

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0928952

    Camera #3 projections: 31% inliers (801/2543) with MSE=0.0789234

    Camera #4 projections: 25% inliers (747/2991) with MSE=0.118341

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 747 vs 747.75

Append camera #24 (IMG_3047.JPG) to alignment via 998 common points

Before BA camera: k1=-4.24116e-08, k2=-4.51124e-14, f=1644.31, cx=339.935, cy=546.166

Before BA projections: 41% inliers with MSE=0.379883

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.392189

    Camera #1 projections: 55% inliers (1010/1846) with MSE=0.263527

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0928952

    Camera #3 projections: 31% inliers (801/2543) with MSE=0.0789234

    Camera #4 projections: 25% inliers (747/2991) with MSE=0.118341

    Camera #5 projections: 23% inliers (702/3070) with MSE=0.167525

    Camera #6 projections: 24% inliers (776/3268) with MSE=0.117274

    Camera #7 projections: 33% inliers (882/2674) with MSE=0.0986755

    Camera #8 projections: 39% inliers (1094/2791) with MSE=0.0759881

    Camera #9 projections: 36% inliers (1020/2867) with MSE=0.10603

    Camera #10 projections: 26% inliers (706/2687) with MSE=0.0789689

    Camera #11 projections: 28% inliers (712/2569) with MSE=0.110079

    Camera #12 projections: 20% inliers (497/2486) with MSE=0.16066

    Camera #13 projections: 30% inliers (710/2404) with MSE=0.158403

    Camera #14 projections: 32% inliers (690/2179) with MSE=0.24932

    Camera #15 projections: 35% inliers (1037/2954) with MSE=0.172689

    Camera #16 projections: 31% inliers (1052/3401) with MSE=0.213391

    Camera #17 projections: 33% inliers (1184/3582) with MSE=0.118899

    Camera #18 projections: 37% inliers (1163/3175) with MSE=0.216623

    Camera #19 projections: 60% inliers (1267/2123) with MSE=0.479692

    Camera #20 projections: 69% inliers (1212/1753) with MSE=0.731109

    Camera #21 projections: 86% inliers (1416/1653) with MSE=1.08628

    Camera #22 projections: 86% inliers (1827/2123) with MSE=0.623029

    Camera #23 projections: 87% inliers (1975/2273) with MSE=0.469858

    Camera #24 projections: 80% inliers (1563/1952) with MSE=1.34616

After BA camera: k1=-8.79047e-08, k2=3.39282e-14, f=1606.99, cx=340.869, cy=552.704

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.8498, 0.0162861, 0.509344] -> [-1.85071, 0.0169931, 0.505405]

Camera #3 center: [-2.63224, 0.0321397, 0.921625] -> [-2.63821, 0.0337752, 0.913602]

Camera #4 center: [-3.20568, 0.068617, 1.48402] -> [-3.2153, 0.0718445, 1.47043]

Camera #5 center: [-3.70946, 0.1144, 2.17267] -> [-3.72688, 0.119697, 2.15645]

Camera #6 center: [-3.92517, 0.187536, 2.97467] -> [-3.95126, 0.194542, 2.95869]

Camera #7 center: [-4.06395, 0.262246, 3.84879] -> [-4.10014, 0.271772, 3.83311]

Camera #8 center: [-3.78234, 0.336704, 4.83956] -> [-3.82783, 0.347834, 4.83292]

Camera #9 center: [-3.41856, 0.386171, 5.74143] -> [-3.47431, 0.399701, 5.74226]

Camera #10 center: [-2.74608, 0.449741, 6.46812] -> [-2.81089, 0.46438, 6.47856]

Camera #11 center: [-2.10245, 0.496781, 6.95839] -> [-2.17333, 0.512872, 6.97954]

Camera #12 center: [-1.33231, 0.554252, 7.40221] -> [-1.41118, 0.5726, 7.43633]

Camera #13 center: [-0.491006, 0.559958, 7.62407] -> [-0.574957, 0.578848, 7.67439]

Camera #14 center: [0.266932, 0.578752, 7.73583] -> [0.185306, 0.59918, 7.80181]

Camera #15 center: [1.04897, 0.562873, 7.62565] -> [0.971488, 0.584298, 7.70711]

Camera #16 center: [1.81705, 0.542294, 7.34581] -> [1.74, 0.564453, 7.44606]

Camera #17 center: [2.50377, 0.490012, 6.8164] -> [2.44112, 0.511509, 6.93219]

Camera #18 center: [3.01159, 0.451446, 6.18694] -> [2.96626, 0.471852, 6.31307]

Camera #19 center: [3.48215, 0.424329, 5.57628] -> [3.45384, 0.444965, 5.71426]

Camera #20 center: [3.95187, 0.38216, 4.94475] -> [3.94283, 0.403378, 5.09508]

Camera #21 center: [4.13328, 0.319551, 4.17392] -> [4.1452, 0.33989, 4.3294]

Camera #22 center: [4.16316, 0.255191, 3.45885] -> [4.19455, 0.271061, 3.57481]

Camera #23 center: [3.98137, 0.195438, 2.77877] -> [4.0372, 0.21369, 2.93514]

Camera #24 center: [3.73935, 0.139635, 2.11047] -> [3.81958, 0.159725, 2.29618]

After BA tie poits: 56% old + 3% new = 59% total outliers

After BA projections: 37% inliers with MSE=0.160049

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.40762

    Camera #1 projections: 55% inliers (1008/1846) with MSE=0.269088

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0970275

    Camera #3 projections: 32% inliers (803/2543) with MSE=0.0821461

    Camera #4 projections: 25% inliers (755/2991) with MSE=0.149106

    Camera #5 projections: 25% inliers (756/3070) with MSE=0.360391

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 756 vs 767.5

Append camera #25 (IMG_3048.JPG) to alignment via 881 common points

Before BA camera: k1=-8.79047e-08, k2=3.39282e-14, f=1606.99, cx=340.869, cy=552.704

Before BA projections: 37% inliers with MSE=0.232508

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.40762

    Camera #1 projections: 55% inliers (1008/1846) with MSE=0.269088

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0970275

    Camera #3 projections: 32% inliers (803/2543) with MSE=0.0821461

    Camera #4 projections: 25% inliers (755/2991) with MSE=0.149106

    Camera #5 projections: 25% inliers (756/3070) with MSE=0.360391

    Camera #6 projections: 24% inliers (777/3268) with MSE=0.121925

    Camera #7 projections: 33% inliers (880/2674) with MSE=0.0938339

    Camera #8 projections: 39% inliers (1099/2791) with MSE=0.109782

    Camera #9 projections: 36% inliers (1040/2867) with MSE=0.177234

    Camera #10 projections: 27% inliers (716/2687) with MSE=0.111002

    Camera #11 projections: 28% inliers (721/2569) with MSE=0.145296

    Camera #12 projections: 20% inliers (507/2486) with MSE=0.201273

    Camera #13 projections: 30% inliers (715/2404) with MSE=0.152474

    Camera #14 projections: 31% inliers (678/2179) with MSE=0.203569

    Camera #15 projections: 34% inliers (1012/2954) with MSE=0.0884101

    Camera #16 projections: 31% inliers (1046/3401) with MSE=0.209801

    Camera #17 projections: 34% inliers (1235/3582) with MSE=0.255668

    Camera #18 projections: 34% inliers (1083/3175) with MSE=0.128714

    Camera #19 projections: 48% inliers (1016/2124) with MSE=0.145466

    Camera #20 projections: 42% inliers (740/1757) with MSE=0.145534

    Camera #21 projections: 42% inliers (693/1664) with MSE=0.107499

    Camera #22 projections: 56% inliers (1197/2144) with MSE=0.134925

    Camera #23 projections: 65% inliers (1609/2466) with MSE=0.171765

    Camera #24 projections: 72% inliers (1867/2602) with MSE=0.272223

    Camera #25 projections: 37% inliers (658/1793) with MSE=2.2586

After BA camera: k1=-5.10153e-08, k2=-2.82939e-14, f=1654.39, cx=339.109, cy=543.563

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85071, 0.0169931, 0.505405] -> [-1.84958, 0.0166519, 0.510014]

Camera #3 center: [-2.63821, 0.0337752, 0.913602] -> [-2.63219, 0.0329875, 0.923446]

Camera #4 center: [-3.2153, 0.0718445, 1.47043] -> [-3.20499, 0.070242, 1.4867]

Camera #5 center: [-3.72688, 0.119697, 2.15645] -> [-3.7079, 0.11697, 2.17654]

Camera #6 center: [-3.95126, 0.194542, 2.95869] -> [-3.92201, 0.191145, 2.97843]

Camera #7 center: [-4.10014, 0.271772, 3.83311] -> [-4.05915, 0.266959, 3.85317]

Camera #8 center: [-3.82783, 0.347834, 4.83292] -> [-3.77499, 0.342742, 4.84417]

Camera #9 center: [-3.47431, 0.399701, 5.74226] -> [-3.40882, 0.393213, 5.74503]

Camera #10 center: [-2.81089, 0.46438, 6.47856] -> [-2.73447, 0.457499, 6.46948]

Camera #11 center: [-2.17333, 0.512872, 6.97954] -> [-2.08936, 0.505021, 6.95784]

Camera #12 center: [-1.41118, 0.5726, 7.43633] -> [-1.31747, 0.562994, 7.39932]

Camera #13 center: [-0.574957, 0.578848, 7.67439] -> [-0.475554, 0.568652, 7.6184]

Camera #14 center: [0.185306, 0.59918, 7.80181] -> [0.283546, 0.586943, 7.72773]

Camera #15 center: [0.971488, 0.584298, 7.70711] -> [1.06544, 0.571142, 7.61434]

Camera #16 center: [1.74, 0.564453, 7.44606] -> [1.83184, 0.549468, 7.332]

Camera #17 center: [2.44112, 0.511509, 6.93219] -> [2.51717, 0.496821, 6.79912]

Camera #18 center: [2.96626, 0.471852, 6.31307] -> [3.02351, 0.45673, 6.16613]

Camera #19 center: [3.45384, 0.444965, 5.71426] -> [3.49154, 0.429051, 5.55143]

Camera #20 center: [3.94283, 0.403378, 5.09508] -> [3.95736, 0.385008, 4.91969]

Camera #21 center: [4.1452, 0.33989, 4.3294] -> [4.1345, 0.321455, 4.14529]

Camera #22 center: [4.19455, 0.271061, 3.57481] -> [4.15604, 0.252377, 3.39081]

Camera #23 center: [4.0372, 0.21369, 2.93514] -> [3.97145, 0.193293, 2.73456]

Camera #24 center: [3.81958, 0.159725, 2.29618] -> [3.71202, 0.140083, 2.08187]

Camera #25 center: [3.32639, 0.0420809, 1.74172] -> [3.26829, 0.106878, 1.5581]

After BA tie poits: 57% old + 2% new = 59% total outliers

After BA projections: 37% inliers with MSE=0.205508

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.382343

    Camera #1 projections: 55% inliers (1007/1846) with MSE=0.248957

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0934947

    Camera #3 projections: 31% inliers (801/2543) with MSE=0.0787079

    Camera #4 projections: 25% inliers (749/2991) with MSE=0.130974

    Camera #5 projections: 23% inliers (705/3070) with MSE=0.174341

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 705 vs 767.5

Append camera #26 (IMG_3049.JPG) to alignment via 769 common points

Before BA camera: k1=-5.10153e-08, k2=-2.82939e-14, f=1654.39, cx=339.109, cy=543.563

Before BA projections: 37% inliers with MSE=0.300253

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.382343

    Camera #1 projections: 55% inliers (1007/1846) with MSE=0.248957

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0934947

    Camera #3 projections: 31% inliers (801/2543) with MSE=0.0787079

    Camera #4 projections: 25% inliers (749/2991) with MSE=0.130974

    Camera #5 projections: 23% inliers (705/3070) with MSE=0.174341

    Camera #6 projections: 24% inliers (776/3268) with MSE=0.118826

    Camera #7 projections: 33% inliers (883/2674) with MSE=0.0963345

    Camera #8 projections: 39% inliers (1094/2791) with MSE=0.0779453

    Camera #9 projections: 36% inliers (1024/2867) with MSE=0.12241

    Camera #10 projections: 26% inliers (706/2687) with MSE=0.0791821

    Camera #11 projections: 28% inliers (710/2569) with MSE=0.101384

    Camera #12 projections: 21% inliers (515/2486) with MSE=0.279891

    Camera #13 projections: 32% inliers (764/2404) with MSE=0.345048

    Camera #14 projections: 35% inliers (756/2179) with MSE=0.528506

    Camera #15 projections: 36% inliers (1064/2954) with MSE=0.300676

    Camera #16 projections: 30% inliers (1035/3401) with MSE=0.187118

    Camera #17 projections: 32% inliers (1162/3582) with MSE=0.10275

    Camera #18 projections: 34% inliers (1073/3175) with MSE=0.187376

    Camera #19 projections: 48% inliers (1012/2130) with MSE=0.262464

    Camera #20 projections: 44% inliers (767/1757) with MSE=0.489756

    Camera #21 projections: 40% inliers (674/1667) with MSE=0.542943

    Camera #22 projections: 38% inliers (827/2152) with MSE=0.456318

    Camera #23 projections: 47% inliers (1180/2491) with MSE=0.257032

    Camera #24 projections: 56% inliers (1527/2715) with MSE=0.131322

    Camera #25 projections: 82% inliers (1774/2156) with MSE=0.34061

    Camera #26 projections: 37% inliers (475/1297) with MSE=3.95956

After BA camera: k1=-4.69244e-08, k2=-3.39512e-14, f=1634.59, cx=341.167, cy=548.567

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.84958, 0.0166519, 0.510014] -> [-1.8499, 0.0160323, 0.508085]

Camera #3 center: [-2.63219, 0.0329875, 0.923446] -> [-2.63301, 0.03154, 0.919014]

Camera #4 center: [-3.20499, 0.070242, 1.4867] -> [-3.20728, 0.0676269, 1.47994]

Camera #5 center: [-3.7079, 0.11697, 2.17654] -> [-3.71267, 0.112955, 2.16744]

Camera #6 center: [-3.92201, 0.191145, 2.97843] -> [-3.93052, 0.185594, 2.9693]

Camera #7 center: [-4.05915, 0.266959, 3.85317] -> [-4.07167, 0.25989, 3.84309]

Camera #8 center: [-3.77499, 0.342742, 4.84417] -> [-3.7929, 0.333745, 4.83469]

Camera #9 center: [-3.40882, 0.393213, 5.74503] -> [-3.43199, 0.3829, 5.73789]

Camera #10 center: [-2.73447, 0.457499, 6.46948] -> [-2.76208, 0.446196, 6.46692]

Camera #11 center: [-2.08936, 0.505021, 6.95784] -> [-2.12029, 0.493179, 6.95963]

Camera #12 center: [-1.31747, 0.562994, 7.39932] -> [-1.35235, 0.550723, 7.40644]

Camera #13 center: [-0.475554, 0.568652, 7.6184] -> [-0.512299, 0.556574, 7.63201]

Camera #14 center: [0.283546, 0.586943, 7.72773] -> [0.245504, 0.575513, 7.74734]

Camera #15 center: [1.06544, 0.571142, 7.61434] -> [1.02842, 0.560263, 7.64065]

Camera #16 center: [1.83184, 0.549468, 7.332] -> [1.79729, 0.540088, 7.36484]

Camera #17 center: [2.51717, 0.496821, 6.79912] -> [2.48654, 0.488507, 6.83903]

Camera #18 center: [3.02351, 0.45673, 6.16613] -> [2.99761, 0.450307, 6.21266]

Camera #19 center: [3.49154, 0.429051, 5.55143] -> [3.47228, 0.423886, 5.60335]

Camera #20 center: [3.95736, 0.385008, 4.91969] -> [3.94568, 0.382021, 4.97368]

Camera #21 center: [4.1345, 0.321455, 4.14529] -> [4.1303, 0.319446, 4.20901]

Camera #22 center: [4.15604, 0.252377, 3.39081] -> [4.16337, 0.254928, 3.47237]

Camera #23 center: [3.97145, 0.193293, 2.73456] -> [3.99503, 0.195566, 2.82517]

Camera #24 center: [3.71202, 0.140083, 2.08187] -> [3.75749, 0.144657, 2.18373]

Camera #25 center: [3.26829, 0.106878, 1.5581] -> [3.32351, 0.108111, 1.64164]

Camera #26 center: [2.73318, 0.107266, 0.98267] -> [2.78506, 0.0476785, 1.07363]

After BA tie poits: 58% old + 1% new = 59% total outliers

After BA projections: 36% inliers with MSE=0.2732

    Camera #0 projections: 52% inliers (707/1358) with MSE=0.404936

    Camera #1 projections: 55% inliers (1021/1846) with MSE=0.296216

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0935236

    Camera #3 projections: 32% inliers (803/2543) with MSE=0.0840183

    Camera #4 projections: 25% inliers (756/2991) with MSE=0.155877

    Camera #5 projections: 23% inliers (703/3070) with MSE=0.172159

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 703 vs 767.5

Append camera #27 (IMG_3050.JPG) to alignment via 654 common points

Before BA camera: k1=-4.69244e-08, k2=-3.39512e-14, f=1634.59, cx=341.167, cy=548.567

Before BA projections: 36% inliers with MSE=0.304819

    Camera #0 projections: 52% inliers (707/1365) with MSE=0.404936

    Camera #1 projections: 55% inliers (1021/1849) with MSE=0.296216

    Camera #2 projections: 39% inliers (965/2484) with MSE=0.0935236

    Camera #3 projections: 32% inliers (803/2543) with MSE=0.0840183

    Camera #4 projections: 25% inliers (756/2991) with MSE=0.155877

    Camera #5 projections: 23% inliers (703/3070) with MSE=0.172159

    Camera #6 projections: 24% inliers (776/3268) with MSE=0.116241

    Camera #7 projections: 33% inliers (880/2674) with MSE=0.0897795

    Camera #8 projections: 39% inliers (1094/2791) with MSE=0.0753667

    Camera #9 projections: 35% inliers (1011/2867) with MSE=0.084488

    Camera #10 projections: 26% inliers (706/2687) with MSE=0.0787708

    Camera #11 projections: 28% inliers (712/2569) with MSE=0.105427

    Camera #12 projections: 20% inliers (492/2486) with MSE=0.131648

    Camera #13 projections: 29% inliers (705/2404) with MSE=0.142509

    Camera #14 projections: 31% inliers (674/2179) with MSE=0.167822

    Camera #15 projections: 35% inliers (1036/2954) with MSE=0.148356

    Camera #16 projections: 31% inliers (1070/3401) with MSE=0.244069

    Camera #17 projections: 34% inliers (1235/3582) with MSE=0.314374

    Camera #18 projections: 38% inliers (1210/3175) with MSE=0.614572

    Camera #19 projections: 58% inliers (1234/2130) with MSE=0.884417

    Camera #20 projections: 57% inliers (1003/1759) with MSE=1.10439

    Camera #21 projections: 41% inliers (689/1667) with MSE=0.818223

    Camera #22 projections: 32% inliers (701/2157) with MSE=0.377393

    Camera #23 projections: 36% inliers (904/2497) with MSE=0.211426

    Camera #24 projections: 40% inliers (1089/2731) with MSE=0.0789786

    Camera #25 projections: 54% inliers (1221/2250) with MSE=0.0578947

    Camera #26 projections: 77% inliers (1281/1658) with MSE=0.198863

    Camera #27 projections: 27% inliers (308/1154) with MSE=2.29906

After BA camera: k1=-8.05092e-08, k2=2.47029e-14, f=1631.32, cx=341.865, cy=553.918

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.8499, 0.0160323, 0.508085] -> [-1.85092, 0.0154619, 0.505014]

Camera #3 center: [-2.63301, 0.03154, 0.919014] -> [-2.63781, 0.0302899, 0.912535]

Camera #4 center: [-3.20728, 0.0676269, 1.47994] -> [-3.2153, 0.0653512, 1.46887]

Camera #5 center: [-3.71267, 0.112955, 2.16744] -> [-3.72699, 0.109909, 2.15375]

Camera #6 center: [-3.93052, 0.185594, 2.9693] -> [-3.95252, 0.181624, 2.95736]

Camera #7 center: [-4.07167, 0.25989, 3.84309] -> [-4.10187, 0.255191, 3.83523]

Camera #8 center: [-3.7929, 0.333745, 4.83469] -> [-3.82923, 0.327951, 4.83529]

Camera #9 center: [-3.43199, 0.3829, 5.73789] -> [-3.47668, 0.376039, 5.74171]

Camera #10 center: [-2.76208, 0.446196, 6.46692] -> [-2.81561, 0.438043, 6.47595]

Camera #11 center: [-2.12029, 0.493179, 6.95963] -> [-2.18243, 0.484692, 6.97478]

Camera #12 center: [-1.35235, 0.550723, 7.40644] -> [-1.43217, 0.541938, 7.42882]

Camera #13 center: [-0.512299, 0.556574, 7.63201] -> [-0.604819, 0.551044, 7.66772]

Camera #14 center: [0.245504, 0.575513, 7.74734] -> [0.147888, 0.571222, 7.80015]

Camera #15 center: [1.02842, 0.560263, 7.64065] -> [0.930195, 0.557617, 7.71234]

Camera #16 center: [1.79729, 0.540088, 7.36484] -> [1.69467, 0.538771, 7.46073]

Camera #17 center: [2.48654, 0.488507, 6.83903] -> [2.39955, 0.489076, 6.95371]

Camera #18 center: [2.99761, 0.450307, 6.21266] -> [2.92781, 0.451179, 6.34245]

Camera #19 center: [3.47228, 0.423886, 5.60335] -> [3.41971, 0.427351, 5.74715]

Camera #20 center: [3.94568, 0.382021, 4.97368] -> [3.91091, 0.386283, 5.13863]

Camera #21 center: [4.1303, 0.319446, 4.20901] -> [4.11731, 0.327948, 4.3809]

Camera #22 center: [4.16337, 0.254928, 3.47237] -> [4.1745, 0.259224, 3.65108]

Camera #23 center: [3.99503, 0.195566, 2.82517] -> [4.02171, 0.205499, 2.98532]

Camera #24 center: [3.75749, 0.144657, 2.18373] -> [3.80636, 0.148947, 2.3377]

Camera #25 center: [3.32351, 0.108111, 1.64164] -> [3.3836, 0.12035, 1.78296]

Camera #26 center: [2.78506, 0.0476785, 1.07363] -> [2.89318, 0.0522515, 1.22606]

Camera #27 center: [2.1896, -0.0285557, 0.58776] -> [2.32022, 0.00855067, 0.778617]

After BA tie poits: 58% old + 1% new = 59% total outliers

After BA projections: 35% inliers with MSE=0.16496

    Camera #0 projections: 52% inliers (711/1365) with MSE=0.426596

    Camera #1 projections: 54% inliers (1007/1849) with MSE=0.262833

    Camera #2 projections: 39% inliers (964/2484) with MSE=0.0972361

    Camera #3 projections: 32% inliers (802/2543) with MSE=0.0825334

    Camera #4 projections: 25% inliers (747/2991) with MSE=0.117475

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 747 vs 747.75

Append camera #28 (IMG_3051.JPG) to alignment via 653 common points

Before BA camera: k1=-8.05092e-08, k2=2.47029e-14, f=1631.32, cx=341.865, cy=553.918

Before BA projections: 34% inliers with MSE=0.195794

    Camera #0 projections: 48% inliers (785/1635) with MSE=0.702496

    Camera #1 projections: 54% inliers (1010/1881) with MSE=0.273404

    Camera #2 projections: 39% inliers (964/2486) with MSE=0.0972361

    Camera #3 projections: 32% inliers (802/2543) with MSE=0.0825334

    Camera #4 projections: 25% inliers (747/2991) with MSE=0.117475

    Camera #5 projections: 23% inliers (703/3070) with MSE=0.170138

    Camera #6 projections: 24% inliers (776/3268) with MSE=0.119224

    Camera #7 projections: 33% inliers (880/2674) with MSE=0.0915802

    Camera #8 projections: 39% inliers (1093/2791) with MSE=0.0780596

    Camera #9 projections: 35% inliers (1011/2867) with MSE=0.0876741

    Camera #10 projections: 26% inliers (707/2687) with MSE=0.0841459

    Camera #11 projections: 28% inliers (708/2569) with MSE=0.109004

    Camera #12 projections: 20% inliers (492/2486) with MSE=0.139788

    Camera #13 projections: 29% inliers (696/2404) with MSE=0.0930403

    Camera #14 projections: 32% inliers (703/2179) with MSE=0.419576

    Camera #15 projections: 41% inliers (1215/2954) with MSE=0.597832

    Camera #16 projections: 31% inliers (1059/3401) with MSE=0.277165

    Camera #17 projections: 33% inliers (1171/3582) with MSE=0.135946

    Camera #18 projections: 33% inliers (1047/3175) with MSE=0.120905

    Camera #19 projections: 45% inliers (952/2130) with MSE=0.134181

    Camera #20 projections: 37% inliers (649/1759) with MSE=0.130623

    Camera #21 projections: 32% inliers (533/1667) with MSE=0.0891454

    Camera #22 projections: 28% inliers (607/2161) with MSE=0.10202

    Camera #23 projections: 31% inliers (770/2504) with MSE=0.0831081

    Camera #24 projections: 32% inliers (881/2735) with MSE=0.0886052

    Camera #25 projections: 44% inliers (996/2256) with MSE=0.107995

    Camera #26 projections: 64% inliers (1090/1694) with MSE=0.0768823

    Camera #27 projections: 69% inliers (1085/1569) with MSE=0.212526

    Camera #28 projections: 11% inliers (166/1462) with MSE=2.7631

After BA camera: k1=-5.37574e-08, k2=7.13713e-16, f=1639.27, cx=351.735, cy=554.085

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85092, 0.0154619, 0.505014] -> [-1.85313, 0.0121209, 0.499582]

Camera #3 center: [-2.63781, 0.0302899, 0.912535] -> [-2.63702, 0.0235548, 0.901408]

Camera #4 center: [-3.2153, 0.0653512, 1.46887] -> [-3.21511, 0.0524412, 1.45237]

Camera #5 center: [-3.72699, 0.109909, 2.15375] -> [-3.7282, 0.0918976, 2.13044]

Camera #6 center: [-3.95252, 0.181624, 2.95736] -> [-3.95876, 0.158298, 2.93145]

Camera #7 center: [-4.10187, 0.255191, 3.83523] -> [-4.11411, 0.225451, 3.80948]

Camera #8 center: [-3.82923, 0.327951, 4.83529] -> [-3.8509, 0.292857, 4.80245]

Camera #9 center: [-3.47668, 0.376039, 5.74171] -> [-3.50847, 0.335612, 5.70576]

Camera #10 center: [-2.81561, 0.438043, 6.47595] -> [-2.85552, 0.395139, 6.44521]

Camera #11 center: [-2.18243, 0.484692, 6.97478] -> [-2.22798, 0.439051, 6.94896]

Camera #12 center: [-1.43217, 0.541938, 7.42882] -> [-1.48493, 0.493369, 7.40782]

Camera #13 center: [-0.604819, 0.551044, 7.66772] -> [-0.666468, 0.503425, 7.65299]

Camera #14 center: [0.147888, 0.571222, 7.80015] -> [0.0787464, 0.522717, 7.7938]

Camera #15 center: [0.930195, 0.557617, 7.71234] -> [0.858782, 0.508962, 7.71758]

Camera #16 center: [1.69467, 0.538771, 7.46073] -> [1.62684, 0.492137, 7.47653]

Camera #17 center: [2.39955, 0.489076, 6.95371] -> [2.3323, 0.445601, 6.98367]

Camera #18 center: [2.92781, 0.451179, 6.34245] -> [2.8657, 0.412781, 6.38659]

Camera #19 center: [3.41971, 0.427351, 5.74715] -> [3.3677, 0.391979, 5.80008]

Camera #20 center: [3.91091, 0.386283, 5.13863] -> [3.86852, 0.354553, 5.19982]

Camera #21 center: [4.11731, 0.327948, 4.3809] -> [4.08972, 0.301052, 4.44352]

Camera #22 center: [4.1745, 0.259224, 3.65108] -> [4.16009, 0.238165, 3.707]

Camera #23 center: [4.02171, 0.205499, 2.98532] -> [4.01976, 0.189349, 3.04544]

Camera #24 center: [3.80636, 0.148947, 2.3377] -> [3.81909, 0.139638, 2.40004]

Camera #25 center: [3.3836, 0.12035, 1.78296] -> [3.41392, 0.114155, 1.8433]

Camera #26 center: [2.89318, 0.0522515, 1.22606] -> [2.92506, 0.0520177, 1.26155]

Camera #27 center: [2.32022, 0.00855067, 0.778617] -> [2.3496, 0.0117253, 0.794271]

Camera #28 center: [1.48914, 0.00233201, 0.445894] -> [1.67431, -0.0041, 0.335411]

After BA tie poits: 57% old + 1% new = 58% total outliers

After BA projections: 34% inliers with MSE=0.131269

    Camera #0 projections: 55% inliers (903/1635) with MSE=0.421725

    Camera #1 projections: 52% inliers (975/1881) with MSE=0.336225

    Camera #2 projections: 39% inliers (964/2486) with MSE=0.117431

    Camera #3 projections: 31% inliers (801/2543) with MSE=0.0984143

    Camera #4 projections: 25% inliers (746/2991) with MSE=0.127898

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 746 vs 747.75

Append camera #29 (IMG_3052.JPG) to alignment via 698 common points

Before BA camera: k1=-5.37574e-08, k2=7.13713e-16, f=1639.27, cx=351.735, cy=554.085

Before BA projections: 35% inliers with MSE=0.236406

    Camera #0 projections: 54% inliers (1076/1990) with MSE=0.611028

    Camera #1 projections: 51% inliers (985/1929) with MSE=0.36592

    Camera #2 projections: 39% inliers (967/2496) with MSE=0.124499

    Camera #3 projections: 32% inliers (805/2554) with MSE=0.118401

    Camera #4 projections: 25% inliers (746/2991) with MSE=0.127898

    Camera #5 projections: 23% inliers (707/3070) with MSE=0.188062

    Camera #6 projections: 24% inliers (776/3268) with MSE=0.110565

    Camera #7 projections: 33% inliers (880/2674) with MSE=0.0860857

    Camera #8 projections: 39% inliers (1093/2791) with MSE=0.0687772

    Camera #9 projections: 35% inliers (1011/2867) with MSE=0.0869917

    Camera #10 projections: 26% inliers (706/2687) with MSE=0.0858889

    Camera #11 projections: 28% inliers (708/2569) with MSE=0.110173

    Camera #12 projections: 20% inliers (487/2486) with MSE=0.100092

    Camera #13 projections: 29% inliers (690/2404) with MSE=0.0761397

    Camera #14 projections: 30% inliers (653/2179) with MSE=0.0974327

    Camera #15 projections: 34% inliers (1008/2954) with MSE=0.0730606

    Camera #16 projections: 30% inliers (1018/3401) with MSE=0.107301

    Camera #17 projections: 32% inliers (1158/3582) with MSE=0.0807327

    Camera #18 projections: 33% inliers (1045/3175) with MSE=0.114428

    Camera #19 projections: 45% inliers (948/2130) with MSE=0.120181

    Camera #20 projections: 37% inliers (646/1759) with MSE=0.131312

    Camera #21 projections: 31% inliers (525/1667) with MSE=0.0885829

    Camera #22 projections: 28% inliers (604/2161) with MSE=0.124016

    Camera #23 projections: 29% inliers (738/2504) with MSE=0.105513

    Camera #24 projections: 29% inliers (783/2735) with MSE=0.0846929

    Camera #25 projections: 36% inliers (818/2256) with MSE=0.0909631

    Camera #26 projections: 52% inliers (882/1694) with MSE=0.0986944

    Camera #27 projections: 62% inliers (1068/1724) with MSE=0.113087

    Camera #28 projections: 80% inliers (1578/1967) with MSE=0.60235

    Camera #29 projections: 43% inliers (795/1844) with MSE=2.44104

After BA camera: k1=-4.58597e-08, k2=-3.21095e-15, f=1636.48, cx=350.316, cy=550.974

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85313, 0.0121209, 0.499582] -> [-1.85926, 0.0122481, 0.500817]

Camera #3 center: [-2.63702, 0.0235548, 0.901408] -> [-2.64655, 0.0238493, 0.902315]

Camera #4 center: [-3.21511, 0.0524412, 1.45237] -> [-3.22816, 0.0531022, 1.45469]

Camera #5 center: [-3.7282, 0.0918976, 2.13044] -> [-3.74451, 0.0924569, 2.13262]

Camera #6 center: [-3.95876, 0.158298, 2.93145] -> [-3.97873, 0.159479, 2.93714]

Camera #7 center: [-4.11411, 0.225451, 3.80948] -> [-4.13795, 0.227472, 3.81825]

Camera #8 center: [-3.8509, 0.292857, 4.80245] -> [-3.87756, 0.296359, 4.81674]

Camera #9 center: [-3.50847, 0.335612, 5.70576] -> [-3.53668, 0.340687, 5.72752]

Camera #10 center: [-2.85552, 0.395139, 6.44521] -> [-2.88248, 0.402203, 6.47473]

Camera #11 center: [-2.22798, 0.439051, 6.94896] -> [-2.25315, 0.44799, 6.9841]

Camera #12 center: [-1.48493, 0.493369, 7.40782] -> [-1.50756, 0.504123, 7.44873]

Camera #13 center: [-0.666468, 0.503425, 7.65299] -> [-0.682968, 0.516323, 7.69877]

Camera #14 center: [0.0787464, 0.522717, 7.7938] -> [0.0661583, 0.537202, 7.8431]

Camera #15 center: [0.858782, 0.508962, 7.71758] -> [0.851845, 0.525256, 7.76901]

Camera #16 center: [1.62684, 0.492137, 7.47653] -> [1.62726, 0.509572, 7.52854]

Camera #17 center: [2.3323, 0.445601, 6.98367] -> [2.33846, 0.463917, 7.0346]

Camera #18 center: [2.8657, 0.412781, 6.38659] -> [2.87667, 0.431426, 6.43598]

Camera #19 center: [3.3677, 0.391979, 5.80008] -> [3.38359, 0.410918, 5.84719]

Camera #20 center: [3.86852, 0.354553, 5.19982] -> [3.88941, 0.373604, 5.24414]

Camera #21 center: [4.08972, 0.301052, 4.44352] -> [4.11447, 0.319415, 4.48314]

Camera #22 center: [4.16009, 0.238165, 3.707] -> [4.18763, 0.255559, 3.74179]

Camera #23 center: [4.01976, 0.189349, 3.04544] -> [4.04846, 0.204993, 3.07684]

Camera #24 center: [3.81909, 0.139638, 2.40004] -> [3.84659, 0.153446, 2.4227]

Camera #25 center: [3.41392, 0.114155, 1.8433] -> [3.43709, 0.125923, 1.85561]

Camera #26 center: [2.92506, 0.0520177, 1.26155] -> [2.9484, 0.0620958, 1.27406]

Camera #27 center: [2.3496, 0.0117253, 0.794271] -> [2.37773, 0.0205903, 0.807585]

Camera #28 center: [1.67431, -0.0041, 0.335411] -> [1.70835, 0.000752673, 0.348262]

Camera #29 center: [0.875582, 0.023352, 0.0753457] -> [0.925589, 5.40612e-05, 0.0626508]

After BA tie poits: 56% old + 1% new = 57% total outliers

After BA projections: 36% inliers with MSE=0.145795

    Camera #0 projections: 60% inliers (1193/1990) with MSE=0.317845

    Camera #1 projections: 51% inliers (979/1929) with MSE=0.368923

    Camera #2 projections: 38% inliers (950/2496) with MSE=0.12108

    Camera #3 projections: 31% inliers (804/2554) with MSE=0.105405

    Camera #4 projections: 25% inliers (745/2991) with MSE=0.134614

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 745 vs 747.75

Append camera #30 (IMG_3053.JPG) to alignment via 1816 common points

Before BA camera: k1=-4.58597e-08, k2=-3.21095e-15, f=1636.48, cx=350.316, cy=550.974

Before BA projections: 38% inliers with MSE=0.399634

    Camera #0 projections: 57% inliers (1694/2947) with MSE=0.837635

    Camera #1 projections: 51% inliers (1050/2063) with MSE=0.497208

    Camera #2 projections: 38% inliers (952/2511) with MSE=0.130402

    Camera #3 projections: 31% inliers (804/2573) with MSE=0.105405

    Camera #4 projections: 25% inliers (745/2995) with MSE=0.134614

    Camera #5 projections: 23% inliers (703/3070) with MSE=0.166442

    Camera #6 projections: 24% inliers (776/3268) with MSE=0.110977

    Camera #7 projections: 33% inliers (880/2674) with MSE=0.0861152

    Camera #8 projections: 39% inliers (1093/2791) with MSE=0.0684531

    Camera #9 projections: 35% inliers (1011/2867) with MSE=0.0835927

    Camera #10 projections: 26% inliers (707/2687) with MSE=0.0889646

    Camera #11 projections: 28% inliers (713/2569) with MSE=0.137028

    Camera #12 projections: 20% inliers (490/2486) with MSE=0.111054

    Camera #13 projections: 29% inliers (692/2404) with MSE=0.0817176

    Camera #14 projections: 30% inliers (653/2179) with MSE=0.0955331

    Camera #15 projections: 34% inliers (1008/2954) with MSE=0.0747078

    Camera #16 projections: 30% inliers (1020/3401) with MSE=0.115834

    Camera #17 projections: 32% inliers (1158/3582) with MSE=0.0817995

    Camera #18 projections: 33% inliers (1045/3175) with MSE=0.114266

    Camera #19 projections: 45% inliers (948/2130) with MSE=0.119025

    Camera #20 projections: 37% inliers (645/1759) with MSE=0.131934

    Camera #21 projections: 31% inliers (523/1667) with MSE=0.0880734

    Camera #22 projections: 27% inliers (591/2161) with MSE=0.0934533

    Camera #23 projections: 29% inliers (718/2504) with MSE=0.0906165

    Camera #24 projections: 27% inliers (751/2735) with MSE=0.0781018

    Camera #25 projections: 34% inliers (760/2256) with MSE=0.0959717

    Camera #26 projections: 44% inliers (748/1694) with MSE=0.13088

    Camera #27 projections: 65% inliers (1119/1724) with MSE=0.483476

    Camera #28 projections: 71% inliers (1501/2120) with MSE=0.261539

    Camera #29 projections: 81% inliers (1809/2222) with MSE=0.366994

    Camera #30 projections: 75% inliers (2675/3573) with MSE=2.3778

After BA camera: k1=-6.6885e-08, k2=4.26999e-14, f=1650.44, cx=346.712, cy=546.602

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.85926, 0.0122481, 0.500817] -> [-1.94798, 0.0177016, 0.537625]

Camera #3 center: [-2.64655, 0.0238493, 0.902315] -> [-2.73655, 0.0366722, 0.958554]

Camera #4 center: [-3.22816, 0.0531022, 1.45469] -> [-3.31454, 0.0712067, 1.52736]

Camera #5 center: [-3.74451, 0.0924569, 2.13262] -> [-3.8257, 0.115323, 2.21966]

Camera #6 center: [-3.97873, 0.159479, 2.93714] -> [-4.05093, 0.185956, 3.03809]

Camera #7 center: [-4.13795, 0.227472, 3.81825] -> [-4.20068, 0.257274, 3.93411]

Camera #8 center: [-3.87756, 0.296359, 4.81674] -> [-3.92158, 0.328135, 4.94866]

Camera #9 center: [-3.53668, 0.340687, 5.72752] -> [-3.5621, 0.373424, 5.87129]

Camera #10 center: [-2.88248, 0.402203, 6.47473] -> [-2.88626, 0.434378, 6.62262]

Camera #11 center: [-2.25315, 0.44799, 6.9841] -> [-2.23874, 0.48013, 7.13244]

Camera #12 center: [-1.50756, 0.504123, 7.44873] -> [-1.47358, 0.535669, 7.59553]

Camera #13 center: [-0.682968, 0.516323, 7.69877] -> [-0.627421, 0.547336, 7.83888]

Camera #14 center: [0.0661583, 0.537202, 7.8431] -> [0.138869, 0.567643, 7.97514]

Camera #15 center: [0.851845, 0.525256, 7.76901] -> [0.937607, 0.554225, 7.88809]

Camera #16 center: [1.62726, 0.509572, 7.52854] -> [1.72019, 0.536659, 7.63312]

Camera #17 center: [2.33846, 0.463917, 7.0346] -> [2.43754, 0.488279, 7.11994]

Camera #18 center: [2.87667, 0.431426, 6.43598] -> [2.97748, 0.453208, 6.50173]

Camera #19 center: [3.38359, 0.410918, 5.84719] -> [3.48405, 0.430833, 5.89601]

Camera #20 center: [3.88941, 0.373604, 5.24414] -> [3.98969, 0.391542, 5.27671]

Camera #21 center: [4.11447, 0.319415, 4.48314] -> [4.20731, 0.335144, 4.50137]

Camera #22 center: [4.18763, 0.255559, 3.74179] -> [4.27145, 0.268852, 3.75031]

Camera #23 center: [4.04846, 0.204993, 3.07684] -> [4.12181, 0.216776, 3.07988]

Camera #24 center: [3.84659, 0.153446, 2.4227] -> [3.9101, 0.162552, 2.41899]

Camera #25 center: [3.43709, 0.125923, 1.85561] -> [3.48635, 0.133797, 1.84681]

Camera #26 center: [2.9484, 0.0620958, 1.27406] -> [2.98485, 0.0669939, 1.2638]

Camera #27 center: [2.37773, 0.0205903, 0.807585] -> [2.40138, 0.0246238, 0.797725]

Camera #28 center: [1.70835, 0.000752673, 0.348262] -> [1.72264, 0.00373234, 0.340385]

Camera #29 center: [0.925589, 5.40612e-05, 0.0626508] -> [0.929215, 0.000838823, 0.0590211]

Camera #30 center: [0.166469, -0.0054691, -0.0896326] -> [0.16594, 0.00013453, -0.0956048]

After BA tie poits: 54% old + 4% new = 58% total outliers

After BA projections: 38% inliers with MSE=0.154468

    Camera #0 projections: 67% inliers (1985/2947) with MSE=0.254957

    Camera #1 projections: 49% inliers (1013/2063) with MSE=0.517452

    Camera #2 projections: 37% inliers (928/2511) with MSE=0.237017

    Camera #3 projections: 32% inliers (815/2573) with MSE=0.138577

    Camera #4 projections: 25% inliers (754/2995) with MSE=0.183311

    Camera #5 projections: 23% inliers (713/3070) with MSE=0.224837

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 713 vs 767.5

Append camera #31 (IMG_3054.JPG) to alignment via 1546 common points

Before BA camera: k1=-6.6885e-08, k2=4.26999e-14, f=1650.44, cx=346.712, cy=546.602

Before BA projections: 37% inliers with MSE=0.221444

    Camera #0 projections: 66% inliers (2046/3077) with MSE=0.320461

    Camera #1 projections: 49% inliers (1278/2606) with MSE=0.857524

    Camera #2 projections: 36% inliers (951/2622) with MSE=0.275598

    Camera #3 projections: 32% inliers (826/2586) with MSE=0.176586

    Camera #4 projections: 25% inliers (756/3000) with MSE=0.192566

    Camera #5 projections: 23% inliers (713/3070) with MSE=0.224837

    Camera #6 projections: 24% inliers (775/3268) with MSE=0.111906

    Camera #7 projections: 33% inliers (880/2674) with MSE=0.0912224

    Camera #8 projections: 39% inliers (1093/2791) with MSE=0.0735524

    Camera #9 projections: 35% inliers (1011/2867) with MSE=0.085048

    Camera #10 projections: 26% inliers (706/2687) with MSE=0.085475

    Camera #11 projections: 28% inliers (717/2569) with MSE=0.167609

    Camera #12 projections: 21% inliers (519/2486) with MSE=0.279881

    Camera #13 projections: 29% inliers (704/2404) with MSE=0.137703

    Camera #14 projections: 30% inliers (655/2179) with MSE=0.114178

    Camera #15 projections: 34% inliers (1008/2954) with MSE=0.0821613

    Camera #16 projections: 30% inliers (1018/3401) with MSE=0.110725

    Camera #17 projections: 32% inliers (1158/3582) with MSE=0.0913298

    Camera #18 projections: 33% inliers (1045/3175) with MSE=0.11655

    Camera #19 projections: 45% inliers (948/2130) with MSE=0.125997

    Camera #20 projections: 37% inliers (645/1759) with MSE=0.135575

    Camera #21 projections: 31% inliers (522/1667) with MSE=0.0907195

    Camera #22 projections: 27% inliers (588/2161) with MSE=0.0949996

    Camera #23 projections: 28% inliers (711/2504) with MSE=0.0935032

    Camera #24 projections: 27% inliers (739/2735) with MSE=0.0756064

    Camera #25 projections: 33% inliers (741/2256) with MSE=0.0979836

    Camera #26 projections: 41% inliers (702/1694) with MSE=0.0776505

    Camera #27 projections: 55% inliers (941/1724) with MSE=0.108022

    Camera #28 projections: 66% inliers (1405/2130) with MSE=0.161437

    Camera #29 projections: 73% inliers (1752/2406) with MSE=0.196027

    Camera #30 projections: 90% inliers (3426/3801) with MSE=0.275083

    Camera #31 projections: 14% inliers (385/2834) with MSE=2.73258

After BA camera: k1=-5.14732e-08, k2=3.26494e-15, f=1639.11, cx=342.915, cy=541.172

Camera #0 center: [0, 0, 0] -> [0, 0, 0]

Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]

Camera #2 center: [-1.94798, 0.0177016, 0.537625] -> [-1.87629, 0.0159485, 0.507182]

Camera #3 center: [-2.73655, 0.0366722, 0.958554] -> [-2.6685, 0.0324239, 0.914348]

Camera #4 center: [-3.31454, 0.0712067, 1.52736] -> [-3.25304, 0.0671103, 1.47389]

Camera #5 center: [-3.8257, 0.115323, 2.21966] -> [-3.77034, 0.112703, 2.15756]

Camera #6 center: [-4.05093, 0.185956, 3.03809] -> [-4.00253, 0.185832, 2.96638]

Camera #7 center: [-4.20068, 0.257274, 3.93411] -> [-4.16136, 0.260159, 3.85586]

Camera #8 center: [-3.92158, 0.328135, 4.94866] -> [-3.89537, 0.335382, 4.86465]

Camera #9 center: [-3.5621, 0.373424, 5.87129] -> [-3.54738, 0.38544, 5.78535]

Camera #10 center: [-2.88626, 0.434378, 6.62262] -> [-2.8833, 0.451053, 6.53779]

Camera #11 center: [-2.23874, 0.48013, 7.13244] -> [-2.24419, 0.500043, 7.0501]

Camera #12 center: [-1.47358, 0.535669, 7.59553] -> [-1.48467, 0.559288, 7.51707]

Camera #13 center: [-0.627421, 0.547336, 7.83888] -> [-0.642744, 0.574022, 7.76439]

Camera #14 center: [0.138869, 0.567643, 7.97514] -> [0.115752, 0.595974, 7.9039]

Camera #15 center: [0.937607, 0.554225, 7.88809] -> [0.90926, 0.583548, 7.8219]

Camera #16 center: [1.72019, 0.536659, 7.63312] -> [1.68946, 0.565966, 7.5722]

Camera #17 center: [2.43754, 0.488279, 7.11994] -> [2.40611, 0.516631, 7.06429]

Camera #18 center: [2.97748, 0.453208, 6.50173] -> [2.94462, 0.479546, 6.45227]

Camera #19 center: [3.48405, 0.430833, 5.89601] -> [3.44804, 0.455394, 5.85428]

Camera #20 center: [3.98969, 0.391542, 5.27671] -> [3.95086, 0.414439, 5.24367]

Camera #21 center: [4.20731, 0.335144, 4.50137] -> [4.16951, 0.355651, 4.47559]

Camera #22 center: [4.27145, 0.268852, 3.75031] -> [4.2354, 0.286787, 3.73157]

Camera #23 center: [4.12181, 0.216776, 3.07988] -> [4.08974, 0.231918, 3.06718]

Camera #24 center: [3.9101, 0.162552, 2.41899] -> [3.88208, 0.175358, 2.41186]

Camera #25 center: [3.48635, 0.133797, 1.84681] -> [3.46422, 0.143773, 1.84304]

Camera #26 center: [2.98485, 0.0669939, 1.2638] -> [2.96925, 0.0750332, 1.26414]

Camera #27 center: [2.40138, 0.0246238, 0.797725] -> [2.39239, 0.0304288, 0.800115]

Camera #28 center: [1.72264, 0.00373234, 0.340385] -> [1.71694, 0.00722618, 0.343708]

Camera #29 center: [0.929215, 0.000838823, 0.0590211] -> [0.926412, 0.00279165, 0.0610539]

Camera #30 center: [0.16594, 0.00013453, -0.0956048] -> [0.163997, 0.000585889, -0.0937147]

Camera #31 center: [-0.616623, -0.0261478, -0.181539] -> [-0.634887, -0.00403779, -0.0663021]

After BA tie poits: 55% old + 2% new = 58% total outliers

After BA projections: 36% inliers with MSE=0.147007

    Camera #0 projections: 39% inliers (1203/3077) with MSE=0.330873

    Camera #1 projections: 47% inliers (1237/2606) with MSE=0.298502

    Camera #2 projections: 36% inliers (948/2622) with MSE=0.150508

    Camera #3 projections: 31% inliers (789/2586) with MSE=0.133186

    Camera #4 projections: 24% inliers (726/3000) with MSE=0.15441

/home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/tests/test_sfm_ba.cpp:740: Failure

Expected: (ninls) > (0.25 * nproj), actual: 726 vs 750

[  FAILED  ] SFM.ReconstructNViews (290872 ms)

[----------] 1 test from SFM (290872 ms total)

[----------] Global test environment tear-down

[==========] 1 test from 1 test suite ran. (290872 ms total)

[  PASSED  ] 0 tests.

[  FAILED  ] 1 test, listed below:

[  FAILED  ] SFM.ReconstructNViews

 1 FAILED TEST
</pre>

</p></details>