### PR TITLE
Task04 Anna Leonova CSC

### DIFF
--- a/src/phg/core/calibration.cpp
+++ b/src/phg/core/calibration.cpp
@@ -35,7 +35,12 @@ cv::Vec3d phg::Calibration::project(const cv::Vec3d &point) const
     double x = f_ * point[0] / point[2];
     double y = f_ * point[1] / point[2];
 
-    // TODO 11: добавьте учет радиальных искажений (k1_, k2_)
+    // TODO 11 -- done: добавьте учет радиальных искажений (k1_, k2_)
+
+    double rr = x*x + y*y;
+
+    x *= 1 + k1_ * rr + k2_ * rr * rr;
+    y *= 1 + k1_ * rr + k2_ * rr * rr;
 
     x += cx_ + width_ * 0.5;
     y += cy_ + height_ * 0.5;
@@ -48,7 +53,12 @@ cv::Vec3d phg::Calibration::unproject(const cv::Vec2d &pixel) const
     double x = pixel[0] - cx_ - width_ * 0.5;
     double y = pixel[1] - cy_ - height_ * 0.5;
 
-    // TODO 12: добавьте учет радиальных искажений, когда реализуете - подумайте: почему строго говоря это - не симметричная формула формуле из project? (но лишь приближение)
+    // TODO 12 -- done: добавьте учет радиальных искажений, когда реализуете - подумайте: почему строго говоря это - не симметричная формула формуле из project? (но лишь приближение)
+
+    double rr = x*x + y*y;
+
+    x /= 1 + k1_ * rr + k2_ * rr * rr;
+    y /= 1 + k1_ * rr + k2_ * rr * rr;
 
     x /= f_;
     y /= f_;


### PR DESCRIPTION
1) test_ceres_solver/FitLine: почему найденная прямая и эталонная - не совпадают? Как это исправить пост-обработкой? Как это исправить формулировкой задачи?

Прямые равны, но коэффициенты у прямых равны coef(ideal) = k * coef(line) - с точностью до константы. Исправить препроцессингом можно приводя к одному и тому же виду(найти k из уравнения выше). Исправить в формулировке задачи можно убрав(зафиксировав) одну из искомых коэффициентов.

2) BA: представьте что вы написали преобразование phg::Calibration -> блок параметров и обратное блок параметров -> phg::Calibration. Как проверить простым образом что эти преобразования сделаны корректно? Что должно быть в логе про процент inliers до/после BA если runBA() вызывать всегда два раза пордяд? Иначе говоря - что следует из того что в идеале runBA() должна быть (мне очень нравится это слово) - [идемпотентна]?

Если вызвать BA дважды, ничего поменяться не должно.

3) Какое максимальное число кадров у вас получилось хорошо выравнять для каждого из датасетов? (проверьте хотя бы saharov32 и herzjesu25) Не забудьте приложить скриншоты.

saharov32 - 32 картинок
![image_2021-03-17_17-17-48](https://user-images.githubusercontent.com/13620271/111482991-7166fc80-8745-11eb-9d07-b0d44e768d50.png)

herzjesu25 - 25 картинок
![3](https://user-images.githubusercontent.com/13620271/111483404-d02c7600-8745-11eb-8b04-c1897158a77f.png)

4) Если бы вычисления в double были абсолютно точны - можно ли было бы назвать вычисления в Calibration::project/unproject строго зеркальными?

Нет, потому что у нас отсутствует знание о том, чему равно r(Мы можем только предполагать, но из-за искажений не является таким)

5) Почему фокальная длина меняется от того что мы уменьшаем картинку? Почему именно f/downscale?

Учитывая фокальную длину мы рассматриваем плоскость на расстоянии f от начала координат(в координатах камеры, если плоскость камеры находится в Oxy). Когда мы делаем downscale, мы уменьшаем расстояние между пикселями и чтобы вернуться к нашей плоскости, нам нужно поделить на downscale.

6) Имеет ли право BA двигать точку отсчета системы координат (т.е. добавить константу ко всем координатам)? Как это повлияет на суммарную Loss?

Да, так как мы не накладываем никаких дополнительных условий на систему координат.

7) Каким образом можно гарантировать чтобы при сравнении нескольких последовательно построенных облаков точек одного и того же датасета (созданных по мере добавления фотографии за фотографией) в MeshLab - облака не были хаотично смещены/отмасштабированы/повернуты друг от друга?

Можем зафиксировать первую камеру, тогда все остальные так или иначе будут к ней привязаны.

100) Если есть - фидбек/идеи по улучшению задания.

Идей по улучшение нет, спасибо большое за домашнее задание. Было очень интересно!

<details><summary>Travis CI</summary><p>

<pre>
$ ./build/test_ceres_solver
Running main() from /home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from CeresSolver
[ RUN      ] CeresSolver.HelloWorld1
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  1.250000e+01    0.00e+00    5.00e+00   0.00e+00   0.00e+00  1.00e+04        0    9.39e-05    3.93e-04
   1  1.249750e-07    1.25e+01    5.00e-04   5.00e+00   1.00e+00  3.00e+04        1    1.05e-04    1.18e-03
   2  1.388518e-16    1.25e-07    1.67e-08   5.00e-04   1.00e+00  9.00e+04        1    5.96e-06    1.20e-03
Ceres Solver Report: Iterations: 3, Initial cost: 1.250000e+01, Final cost: 1.388518e-16, Termination: CONVERGENCE
x:     5 -> 10
f(x):  5 -> 1.66644e-08
f'(x): -1 -> -1
[       OK ] CeresSolver.HelloWorld1 (1 ms)
[ RUN      ] CeresSolver.HelloWorld2
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  6.906250e+04    0.00e+00    1.52e+04   0.00e+00   0.00e+00  1.00e+04        0    7.87e-06    1.67e-05
   1  2.569682e+03    6.65e+04    1.83e+03   1.26e+02   9.63e-01  3.00e+04        1    1.41e-05    5.27e-05
   2  1.651192e+02    2.40e+03    3.68e+02   2.88e+01   9.36e-01  8.87e+04        1    7.87e-06    7.46e-05
   3  1.220700e+01    1.53e+02    8.51e+01   1.29e+01   9.26e-01  2.33e+05        1    5.96e-06    9.47e-05
   4  1.383213e+00    1.08e+01    2.60e+01   8.51e+00   8.87e-01  4.33e+05        1    5.96e-06    1.14e-04
   5  1.156496e-01    1.27e+00    8.07e+00   1.13e+01   9.16e-01  1.03e+06        1    7.87e-06    1.42e-04
   6  1.068210e-02    1.05e-01    2.52e+00   5.72e+00   9.08e-01  2.24e+06        1    6.91e-06    1.60e-04
   7  9.114024e-04    9.77e-03    7.48e-01   3.23e+00   9.15e-01  5.21e+06        1    6.91e-06    1.78e-04
   8  7.165090e-05    8.40e-04    2.11e-01   1.80e+00   9.21e-01  1.30e+07        1    8.11e-06    1.96e-04
   9  5.330001e-06    6.63e-05    5.79e-02   9.76e-01   9.26e-01  3.39e+07        1    5.01e-06    2.18e-04
  10  3.824134e-07    4.95e-06    1.55e-02   5.18e-01   9.28e-01  9.11e+07        1    6.20e-06    2.35e-04
  11  2.681046e-08    3.56e-07    4.11e-03   2.71e-01   9.30e-01  2.50e+08        1    5.96e-06    2.52e-04
  12  1.853666e-09    2.50e-08    1.08e-03   1.40e-01   9.31e-01  6.95e+08        1    5.96e-06    2.67e-04
  13  1.272860e-10    1.73e-09    2.82e-04   7.25e-02   9.31e-01  1.94e+09        1    5.01e-06    2.82e-04
  14  8.734281e-12    1.19e-10    7.35e-05   3.73e-02   9.31e-01  5.43e+09        1    5.01e-06    2.95e-04
  15  6.026439e-13    8.13e-12    1.92e-05   1.92e-02   9.31e-01  1.51e+10        1    5.01e-06    3.06e-04
  16  4.210414e-14    5.61e-13    5.03e-06   9.87e-03   9.30e-01  4.18e+10        1    3.81e-06    3.16e-04
  17  3.004234e-15    3.91e-14    1.33e-06   5.10e-03   9.29e-01  1.14e+11        1    4.05e-06    3.31e-04
  18  2.213005e-16    2.78e-15    3.55e-07   2.64e-03   9.27e-01  3.02e+11        1    5.01e-06    3.41e-04
  19  1.706207e-17    2.04e-16    9.62e-08   1.38e-03   9.25e-01  7.81e+11        1    4.05e-06    3.51e-04
  20  1.400728e-18    1.57e-17    2.67e-08   7.29e-04   9.21e-01  1.94e+12        1    4.05e-06    3.61e-04
  21  1.250332e-19    1.28e-18    7.61e-09   3.90e-04   9.17e-01  4.60e+12        1    5.01e-06    3.72e-04
  22  1.243382e-20    1.13e-19    2.25e-09   2.12e-04   9.11e-01  1.04e+13        1    5.01e-06    3.82e-04
  23  1.414540e-21    1.10e-20    6.95e-10   1.18e-04   9.05e-01  2.22e+13        1    5.01e-06    3.92e-04
  24  1.879111e-22    1.23e-21    2.26e-10   6.73e-05   9.00e-01  4.54e+13        1    5.01e-06    4.02e-04
  25  2.966799e-23    1.58e-22    7.90e-11   3.96e-05   8.94e-01  8.87e+13        1    5.01e-06    4.13e-04
Ceres Solver Report: Iterations: 26, Initial cost: 6.906250e+04, Final cost: 2.966799e-23, Termination: CONVERGENCE
Found intersection point: (10, 5, 200)
[       OK ] CeresSolver.HelloWorld2 (1 ms)
[ RUN      ] CeresSolver.FitLineNoise
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  4.506761e+07    0.00e+00    1.61e+08   0.00e+00   0.00e+00  1.00e+04        0    1.61e-04    2.26e-04
   1  4.658321e+02    4.51e+07    1.33e+04   1.00e+02   1.00e+00  3.00e+04        1    3.74e-04    6.23e-04
   2  4.654480e+02    3.84e-01    1.61e-01   5.13e-03   1.00e+00  9.00e+04        1    3.53e-04    1.00e-03
Ceres Solver Report: Iterations: 3, Initial cost: 4.506761e+07, Final cost: 4.654480e+02, Termination: CONVERGENCE
Found line: (a=-0.500026, b=0.999948, c=-100.052)
[       OK ] CeresSolver.FitLineNoise (2 ms)
[ RUN      ] CeresSolver.FitLineNoiseAndOutliers
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  1.201187e+08    0.00e+00    1.37e+08   0.00e+00   0.00e+00  1.00e+04        0    1.50e-04    1.85e-04
   1  7.448902e+07    4.56e+07    5.33e+07   8.51e+01   1.41e+00  3.00e+04        1    3.73e-04    5.80e-04
   2  6.772855e+07    6.76e+06    1.27e+07   1.55e+01   1.41e+00  9.00e+04        1    3.43e-04    9.49e-04
   3  6.739936e+07    3.29e+05    3.88e+06   2.30e+00   1.33e+00  2.70e+05        1    3.09e-04    1.28e-03
   4  6.736832e+07    3.10e+04    1.21e+06   6.64e-01   1.32e+00  8.10e+05        1    3.01e-04    1.61e-03
   5  6.736525e+07    3.07e+03    3.83e+05   2.05e-01   1.32e+00  2.43e+06        1    3.62e-04    1.99e-03
   6  6.736495e+07    3.06e+02    1.21e+05   6.45e-02   1.32e+00  7.29e+06        1    3.69e-04    2.38e-03
Ceres Solver Report: Iterations: 7, Initial cost: 1.201187e+08, Final cost: 6.736495e+07, Termination: CONVERGENCE
Found line: (a=-0.549481, b=0.767491, c=-66.3904)
[       OK ] CeresSolver.FitLineNoiseAndOutliers (3 ms)
[ RUN      ] CeresSolver.FitLineNoiseAndOutliersWithHuberLoss
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  1.096949e+06    0.00e+00    1.13e+06   0.00e+00   0.00e+00  1.00e+04        0    1.43e-04    1.77e-04
   1  5.506564e+05    5.46e+05    1.19e+06   8.24e+01   2.14e+00  3.00e+04        1    3.50e-04    5.52e-04
   2  4.578101e+05    9.28e+04    9.63e+05   6.74e+00   1.74e+00  9.00e+04        1    4.43e-04    1.02e-03
   3  4.504957e+05    7.31e+03    2.85e+05   3.04e-01   1.65e+00  2.70e+05        1    3.68e-04    1.41e-03
   4  4.503340e+05    1.62e+02    4.22e+03   1.43e-02   1.02e+00  8.10e+05        1    3.82e-04    1.82e-03
Ceres Solver Report: Iterations: 5, Initial cost: 1.096949e+06, Final cost: 4.503340e+05, Termination: CONVERGENCE
Found line: (a=-0.445255, b=0.889226, c=-88.902)
[       OK ] CeresSolver.FitLineNoiseAndOutliersWithHuberLoss (3 ms)
[----------] 5 tests from CeresSolver (10 ms total)
[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (10 ms total)
[  PASSED  ] 5 tests.
The command "./build/test_ceres_solver" exited with 0.
36.28s$ ./build/test_sfm_ba
Running main() from /home/travis/build/PhotogrammetryCourse/PhotogrammetryTasks2021/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from SFM
[ RUN      ] SFM.ReconstructNViews
32 images
detecting points...
matching points...
1% - Cameras 0-1 (IMG_3023.JPG-IMG_3024.JPG): 1159 matches
3% - Cameras 0-2 (IMG_3023.JPG-IMG_3025.JPG): 442 matches
4% - Cameras 5-1 (IMG_3028.JPG-IMG_3024.JPG): 24 matches
6% - Cameras 0-3 (IMG_3023.JPG-IMG_3026.JPG): 148 matches
7% - Cameras 5-2 (IMG_3028.JPG-IMG_3025.JPG): 132 matches
8% - Cameras 0-4 (IMG_3023.JPG-IMG_3027.JPG): 53 matches
9% - Cameras 5-3 (IMG_3028.JPG-IMG_3026.JPG): 824 matches
11% - Cameras 5-4 (IMG_3028.JPG-IMG_3027.JPG): 1391 matches
13% - Cameras 5-6 (IMG_3028.JPG-IMG_3029.JPG): 1739 matches
16% - Cameras 5-7 (IMG_3028.JPG-IMG_3030.JPG): 1074 matches
18% - Cameras 5-8 (IMG_3028.JPG-IMG_3031.JPG): 391 matches
20% - Cameras 5-9 (IMG_3028.JPG-IMG_3032.JPG): 318 matches
21% - Cameras 1-0 (IMG_3024.JPG-IMG_3023.JPG): 1021 matches
23% - Cameras 1-2 (IMG_3024.JPG-IMG_3025.JPG): 1145 matches
24% - Cameras 6-1 (IMG_3029.JPG-IMG_3024.JPG): 12 matches
26% - Cameras 1-3 (IMG_3024.JPG-IMG_3026.JPG): 344 matches
27% - Cameras 6-2 (IMG_3029.JPG-IMG_3025.JPG): 26 matches
28% - Cameras 1-4 (IMG_3024.JPG-IMG_3027.JPG): 128 matches
29% - Cameras 6-3 (IMG_3029.JPG-IMG_3026.JPG): 294 matches
31% - Cameras 6-4 (IMG_3029.JPG-IMG_3027.JPG): 893 matches
33% - Cameras 6-5 (IMG_3029.JPG-IMG_3028.JPG): 1695 matches
36% - Cameras 6-7 (IMG_3029.JPG-IMG_3030.JPG): 1557 matches
38% - Cameras 6-8 (IMG_3029.JPG-IMG_3031.JPG): 797 matches
40% - Cameras 6-9 (IMG_3029.JPG-IMG_3032.JPG): 470 matches
41% - Cameras 2-0 (IMG_3025.JPG-IMG_3023.JPG): 509 matches
43% - Cameras 2-1 (IMG_3025.JPG-IMG_3024.JPG): 1157 matches
46% - Cameras 2-3 (IMG_3025.JPG-IMG_3026.JPG): 1256 matches
47% - Cameras 7-2 (IMG_3030.JPG-IMG_3025.JPG): 8 matches
48% - Cameras 2-4 (IMG_3025.JPG-IMG_3027.JPG): 648 matches
49% - Cameras 7-3 (IMG_3030.JPG-IMG_3026.JPG): 103 matches
50% - Cameras 2-5 (IMG_3025.JPG-IMG_3028.JPG): 116 matches
51% - Cameras 7-4 (IMG_3030.JPG-IMG_3027.JPG): 308 matches
52% - Cameras 2-6 (IMG_3025.JPG-IMG_3029.JPG): 56 matches
53% - Cameras 7-5 (IMG_3030.JPG-IMG_3028.JPG): 995 matches
54% - Cameras 2-7 (IMG_3025.JPG-IMG_3030.JPG): 38 matches
56% - Cameras 7-6 (IMG_3030.JPG-IMG_3029.JPG): 1562 matches
58% - Cameras 7-8 (IMG_3030.JPG-IMG_3031.JPG): 1221 matches
60% - Cameras 7-9 (IMG_3030.JPG-IMG_3032.JPG): 735 matches
61% - Cameras 3-0 (IMG_3026.JPG-IMG_3023.JPG): 156 matches
63% - Cameras 3-1 (IMG_3026.JPG-IMG_3024.JPG): 390 matches
66% - Cameras 3-2 (IMG_3026.JPG-IMG_3025.JPG): 1200 matches
68% - Cameras 3-4 (IMG_3026.JPG-IMG_3027.JPG): 1551 matches
69% - Cameras 8-3 (IMG_3031.JPG-IMG_3026.JPG): 39 matches
70% - Cameras 3-5 (IMG_3026.JPG-IMG_3028.JPG): 698 matches
71% - Cameras 8-4 (IMG_3031.JPG-IMG_3027.JPG): 159 matches
72% - Cameras 3-6 (IMG_3026.JPG-IMG_3029.JPG): 280 matches
73% - Cameras 8-5 (IMG_3031.JPG-IMG_3028.JPG): 392 matches
74% - Cameras 3-7 (IMG_3026.JPG-IMG_3030.JPG): 85 matches
76% - Cameras 8-6 (IMG_3031.JPG-IMG_3029.JPG): 864 matches
78% - Cameras 8-7 (IMG_3031.JPG-IMG_3030.JPG): 1246 matches
80% - Cameras 8-9 (IMG_3031.JPG-IMG_3032.JPG): 1581 matches
81% - Cameras 4-0 (IMG_3027.JPG-IMG_3023.JPG): 82 matches
83% - Cameras 4-1 (IMG_3027.JPG-IMG_3024.JPG): 173 matches
86% - Cameras 4-2 (IMG_3027.JPG-IMG_3025.JPG): 642 matches
88% - Cameras 4-3 (IMG_3027.JPG-IMG_3026.JPG): 1679 matches
90% - Cameras 4-5 (IMG_3027.JPG-IMG_3028.JPG): 1382 matches
91% - Cameras 9-4 (IMG_3032.JPG-IMG_3027.JPG): 48 matches
92% - Cameras 4-6 (IMG_3027.JPG-IMG_3029.JPG): 1040 matches
93% - Cameras 9-5 (IMG_3032.JPG-IMG_3028.JPG): 296 matches
94% - Cameras 4-7 (IMG_3027.JPG-IMG_3030.JPG): 290 matches
96% - Cameras 9-6 (IMG_3032.JPG-IMG_3029.JPG): 456 matches
97% - Cameras 4-8 (IMG_3027.JPG-IMG_3031.JPG): 158 matches
98% - Cameras 9-7 (IMG_3032.JPG-IMG_3030.JPG): 756 matches
99% - Cameras 4-9 (IMG_3027.JPG-IMG_3032.JPG): 119 matches
100% - Cameras 9-8 (IMG_3032.JPG-IMG_3031.JPG): 1568 matches
Initial alignment from cameras #0 and #1 (IMG_3023.JPG, IMG_3024.JPG)
Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Before BA projections: 89% inliers with MSE=1.71016
    Camera #0 projections: 89% inliers (1037/1159) with MSE=1.68797
    Camera #1 projections: 89% inliers (1035/1159) with MSE=1.73239
After BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
After BA tie poits: 0% old + 11% new = 11% total outliers
After BA projections: 89% inliers with MSE=0.36941
    Camera #0 projections: 89% inliers (1027/1159) with MSE=0.374369
    Camera #1 projections: 89% inliers (1028/1159) with MSE=0.364456
Append camera #2 (IMG_3025.JPG) to alignment via 792 common points
Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Before BA projections: 64% inliers with MSE=0.697122
    Camera #0 projections: 83% inliers (1095/1324) with MSE=0.392793
    Camera #1 projections: 77% inliers (1386/1810) with MSE=0.569545
    Camera #2 projections: 35% inliers (577/1639) with MSE=1.58111
After BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.75432, 0.0435193, 0.691639] -> [-1.9332, 0.0213844, 0.574549]
After BA tie poits: 7% old + 14% new = 21% total outliers
After BA projections: 89% inliers with MSE=0.650715
    Camera #0 projections: 84% inliers (1109/1324) with MSE=0.98434
    Camera #1 projections: 89% inliers (1604/1810) with MSE=0.752057
    Camera #2 projections: 93% inliers (1518/1639) with MSE=0.299898
Append camera #3 (IMG_3026.JPG) to alignment via 886 common points
Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Before BA projections: 83% inliers with MSE=0.821945
    Camera #0 projections: 84% inliers (1121/1339) with MSE=0.996961
    Camera #1 projections: 88% inliers (1643/1859) with MSE=0.748528
    Camera #2 projections: 93% inliers (2133/2288) with MSE=0.402078
    Camera #3 projections: 63% inliers (1028/1622) with MSE=1.61961
After BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.9332, 0.0213844, 0.574549] -> [-1.91389, 0.00594082, 0.493858]
Camera #3 center: [-2.77406, 0.0336863, 1.13333] -> [-2.7575, 0.0109359, 0.902197]
After BA tie poits: 16% old + 5% new = 21% total outliers
After BA projections: 85% inliers with MSE=0.379426
    Camera #0 projections: 81% inliers (1088/1339) with MSE=0.962662
    Camera #1 projections: 85% inliers (1578/1859) with MSE=0.487007
    Camera #2 projections: 84% inliers (1917/2288) with MSE=0.134881
    Camera #3 projections: 92% inliers (1493/1622) with MSE=0.154691
Append camera #4 (IMG_3027.JPG) to alignment via 1117 common points
Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Before BA projections: 85% inliers with MSE=0.616131
    Camera #0 projections: 81% inliers (1095/1347) with MSE=0.960442
    Camera #1 projections: 85% inliers (1590/1873) with MSE=0.486573
    Camera #2 projections: 84% inliers (2069/2471) with MSE=0.15682
    Camera #3 projections: 93% inliers (2361/2539) with MSE=0.266547
    Camera #4 projections: 81% inliers (1974/2437) with MSE=1.42903
After BA camera: k1=0, k2=0, f=1545.15, cx=319.753, cy=522.082
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.91389, 0.00594082, 0.493858] -> [-1.8738, 0.0210645, 0.519138]
Camera #3 center: [-2.7575, 0.0109359, 0.902197] -> [-2.66512, 0.0405331, 0.920834]
Camera #4 center: [-3.37032, 0.0480662, 1.47841] -> [-3.24815, 0.0828439, 1.47663]
After BA tie poits: 15% old + 14% new = 28% total outliers
After BA projections: 82% inliers with MSE=0.20816
    Camera #0 projections: 66% inliers (888/1347) with MSE=0.496857
    Camera #1 projections: 81% inliers (1522/1873) with MSE=0.23003
    Camera #2 projections: 80% inliers (1983/2471) with MSE=0.14821
    Camera #3 projections: 90% inliers (2280/2539) with MSE=0.17139
    Camera #4 projections: 83% inliers (2025/2437) with MSE=0.165232
Append camera #5 (IMG_3028.JPG) to alignment via 1104 common points
Before BA camera: k1=0, k2=0, f=1545.15, cx=319.753, cy=522.082
Before BA projections: 83% inliers with MSE=0.337374
    Camera #0 projections: 66% inliers (888/1347) with MSE=0.496857
    Camera #1 projections: 81% inliers (1523/1875) with MSE=0.230057
    Camera #2 projections: 80% inliers (1988/2478) with MSE=0.148285
    Camera #3 projections: 90% inliers (2476/2755) with MSE=0.267757
    Camera #4 projections: 86% inliers (2632/3077) with MSE=0.257446
    Camera #5 projections: 87% inliers (1749/2020) with MSE=0.783616
After BA camera: k1=0, k2=0, f=1554.42, cx=319.896, cy=519.047
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.8738, 0.0210645, 0.519138] -> [-1.87538, 0.0220595, 0.524057]
Camera #3 center: [-2.66512, 0.0405331, 0.920834] -> [-2.66458, 0.0438812, 0.935192]
Camera #4 center: [-3.24815, 0.0828439, 1.47663] -> [-3.23656, 0.0881176, 1.49282]
Camera #5 center: [-3.77941, 0.129649, 2.14791] -> [-3.75618, 0.141413, 2.17973]
After BA tie poits: 23% old + 4% new = 27% total outliers
After BA projections: 76% inliers with MSE=0.196591
    Camera #0 projections: 66% inliers (887/1347) with MSE=0.496867
    Camera #1 projections: 80% inliers (1506/1875) with MSE=0.237996
    Camera #2 projections: 71% inliers (1771/2478) with MSE=0.112664
    Camera #3 projections: 76% inliers (2098/2755) with MSE=0.143233
    Camera #4 projections: 73% inliers (2258/3077) with MSE=0.161541
    Camera #5 projections: 89% inliers (1801/2020) with MSE=0.20271
Append camera #6 (IMG_3029.JPG) to alignment via 1366 common points
Before BA camera: k1=0, k2=0, f=1554.42, cx=319.896, cy=519.047
Before BA projections: 78% inliers with MSE=0.468045
    Camera #0 projections: 66% inliers (887/1347) with MSE=0.496867
    Camera #1 projections: 80% inliers (1508/1878) with MSE=0.238444
    Camera #2 projections: 72% inliers (1774/2481) with MSE=0.112736
    Camera #3 projections: 76% inliers (2111/2771) with MSE=0.145264
    Camera #4 projections: 75% inliers (2491/3326) with MSE=0.213607
    Camera #5 projections: 90% inliers (2634/2924) with MSE=0.301999
    Camera #6 projections: 83% inliers (2188/2644) with MSE=1.70367
After BA camera: k1=-1.53363e-07, k2=1.4492e-13, f=1518.74, cx=306.173, cy=520.212
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87538, 0.0220595, 0.524057] -> [-1.87703, 0.0295985, 0.520279]
Camera #3 center: [-2.66458, 0.0438812, 0.935192] -> [-2.70141, 0.0622978, 0.944172]
Camera #4 center: [-3.23656, 0.0881176, 1.49282] -> [-3.30319, 0.125013, 1.52312]
Camera #5 center: [-3.75618, 0.141413, 2.17973] -> [-3.8334, 0.198374, 2.21826]
Camera #6 center: [-3.98477, 0.234792, 3.00347] -> [-4.06997, 0.302618, 3.0334]
After BA tie poits: 21% old + 12% new = 33% total outliers
After BA projections: 77% inliers with MSE=0.17255
    Camera #0 projections: 64% inliers (864/1347) with MSE=0.346821
    Camera #1 projections: 80% inliers (1494/1878) with MSE=0.207399
    Camera #2 projections: 70% inliers (1749/2481) with MSE=0.0916292
    Camera #3 projections: 73% inliers (2022/2771) with MSE=0.0929692
    Camera #4 projections: 72% inliers (2381/3326) with MSE=0.159176
    Camera #5 projections: 86% inliers (2527/2924) with MSE=0.202306
    Camera #6 projections: 87% inliers (2313/2644) with MSE=0.196962
Append camera #7 (IMG_3030.JPG) to alignment via 1626 common points
Before BA camera: k1=-1.53363e-07, k2=1.4492e-13, f=1518.74, cx=306.173, cy=520.212
Before BA projections: 79% inliers with MSE=0.431133
    Camera #0 projections: 64% inliers (864/1347) with MSE=0.346821
    Camera #1 projections: 80% inliers (1494/1878) with MSE=0.207399
    Camera #2 projections: 70% inliers (1749/2481) with MSE=0.0916292
    Camera #3 projections: 73% inliers (2028/2778) with MSE=0.0944117
    Camera #4 projections: 72% inliers (2399/3350) with MSE=0.160879
    Camera #5 projections: 87% inliers (2727/3151) with MSE=0.218063
    Camera #6 projections: 89% inliers (2946/3327) with MSE=0.224844
    Camera #7 projections: 89% inliers (2345/2635) with MSE=1.93257
After BA camera: k1=-1.1739e-07, k2=1.01242e-13, f=1539.93, cx=308.699, cy=547.14
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87703, 0.0295985, 0.520279] -> [-1.87116, 0.0235411, 0.520742]
Camera #3 center: [-2.70141, 0.0622978, 0.944172] -> [-2.68645, 0.0469204, 0.945131]
Camera #4 center: [-3.30319, 0.125013, 1.52312] -> [-3.28235, 0.0961449, 1.52426]
Camera #5 center: [-3.8334, 0.198374, 2.21826] -> [-3.80667, 0.153284, 2.22386]
Camera #6 center: [-4.06997, 0.302618, 3.0334] -> [-4.03955, 0.24026, 3.0525]
Camera #7 center: [-4.25748, 0.416488, 3.91959] -> [-4.19924, 0.332021, 3.95802]
After BA tie poits: 28% old + 3% new = 31% total outliers
After BA projections: 73% inliers with MSE=0.140177
    Camera #0 projections: 56% inliers (759/1347) with MSE=0.268721
    Camera #1 projections: 69% inliers (1303/1878) with MSE=0.15419
    Camera #2 projections: 67% inliers (1651/2481) with MSE=0.0708339
    Camera #3 projections: 66% inliers (1840/2778) with MSE=0.0660057
    Camera #4 projections: 64% inliers (2144/3350) with MSE=0.102677
    Camera #5 projections: 77% inliers (2427/3151) with MSE=0.163893
    Camera #6 projections: 82% inliers (2725/3327) with MSE=0.16129
    Camera #7 projections: 89% inliers (2341/2635) with MSE=0.183084
Append camera #8 (IMG_3031.JPG) to alignment via 1518 common points
Before BA camera: k1=-1.1739e-07, k2=1.01242e-13, f=1539.93, cx=308.699, cy=547.14
Before BA projections: 74% inliers with MSE=0.419166
    Camera #0 projections: 56% inliers (759/1347) with MSE=0.268721
    Camera #1 projections: 69% inliers (1303/1878) with MSE=0.15419
    Camera #2 projections: 67% inliers (1651/2481) with MSE=0.0708339
    Camera #3 projections: 66% inliers (1841/2782) with MSE=0.0662844
    Camera #4 projections: 64% inliers (2151/3364) with MSE=0.106219
    Camera #5 projections: 77% inliers (2457/3190) with MSE=0.169446
    Camera #6 projections: 83% inliers (2932/3549) with MSE=0.2573
    Camera #7 projections: 90% inliers (2806/3129) with MSE=0.279525
    Camera #8 projections: 85% inliers (1988/2351) with MSE=2.34942
After BA camera: k1=-7.42078e-08, k2=-1.05338e-14, f=1590.3, cx=317.399, cy=542.828
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87116, 0.0235411, 0.520742] -> [-1.87339, 0.0208248, 0.517368]
Camera #3 center: [-2.68645, 0.0469204, 0.945131] -> [-2.6871, 0.0410259, 0.939045]
Camera #4 center: [-3.28235, 0.0961449, 1.52426] -> [-3.28385, 0.0862968, 1.51661]
Camera #5 center: [-3.80667, 0.153284, 2.22386] -> [-3.81046, 0.139232, 2.22144]
Camera #6 center: [-4.03955, 0.24026, 3.0525] -> [-4.04528, 0.223884, 3.05871]
Camera #7 center: [-4.19924, 0.332021, 3.95802] -> [-4.19882, 0.312233, 3.97697]
Camera #8 center: [-3.94148, 0.428829, 4.99462] -> [-3.91138, 0.39877, 5.0142]
After BA tie poits: 28% old + 2% new = 31% total outliers
After BA projections: 73% inliers with MSE=0.147528
    Camera #0 projections: 56% inliers (757/1347) with MSE=0.316079
    Camera #1 projections: 70% inliers (1310/1878) with MSE=0.212603
    Camera #2 projections: 66% inliers (1637/2481) with MSE=0.0740187
    Camera #3 projections: 65% inliers (1818/2782) with MSE=0.0726841
    Camera #4 projections: 63% inliers (2103/3364) with MSE=0.124183
    Camera #5 projections: 74% inliers (2353/3190) with MSE=0.141585
    Camera #6 projections: 79% inliers (2798/3549) with MSE=0.149064
    Camera #7 projections: 86% inliers (2694/3129) with MSE=0.145741
    Camera #8 projections: 90% inliers (2109/2351) with MSE=0.198334
Append camera #9 (IMG_3032.JPG) to alignment via 1571 common points
Before BA camera: k1=-7.42078e-08, k2=-1.05338e-14, f=1590.3, cx=317.399, cy=542.828
Before BA projections: 76% inliers with MSE=0.238492
    Camera #0 projections: 56% inliers (757/1347) with MSE=0.316079
    Camera #1 projections: 70% inliers (1310/1878) with MSE=0.212603
    Camera #2 projections: 66% inliers (1637/2481) with MSE=0.0740187
    Camera #3 projections: 65% inliers (1818/2782) with MSE=0.0726841
    Camera #4 projections: 63% inliers (2111/3372) with MSE=0.127798
    Camera #5 projections: 74% inliers (2369/3209) with MSE=0.143866
    Camera #6 projections: 79% inliers (2815/3574) with MSE=0.150185
    Camera #7 projections: 86% inliers (2832/3283) with MSE=0.168705
    Camera #8 projections: 91% inliers (2922/3198) with MSE=0.26655
    Camera #9 projections: 92% inliers (2455/2674) with MSE=0.795695
After BA camera: k1=-1.02052e-07, k2=3.80924e-14, f=1627.84, cx=315.574, cy=533.091
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87339, 0.0208248, 0.517368] -> [-1.87476, 0.0219388, 0.519055]
Camera #3 center: [-2.6871, 0.0410259, 0.939045] -> [-2.69163, 0.0436043, 0.945284]
Camera #4 center: [-3.28385, 0.0862968, 1.51661] -> [-3.28865, 0.0918799, 1.52709]
Camera #5 center: [-3.81046, 0.139232, 2.22144] -> [-3.81116, 0.147822, 2.23387]
Camera #6 center: [-4.04528, 0.223884, 3.05871] -> [-4.0406, 0.236059, 3.06757]
Camera #7 center: [-4.19882, 0.312233, 3.97697] -> [-4.19036, 0.327069, 3.97685]
Camera #8 center: [-3.91138, 0.39877, 5.0142] -> [-3.91003, 0.415568, 4.98833]
Camera #9 center: [-3.55198, 0.459657, 5.93269] -> [-3.52197, 0.483041, 5.96351]
After BA tie poits: 27% old + 2% new = 29% total outliers
After BA projections: 74% inliers with MSE=0.15243
    Camera #0 projections: 56% inliers (756/1347) with MSE=0.294492
    Camera #1 projections: 69% inliers (1291/1878) with MSE=0.156972
    Camera #2 projections: 66% inliers (1631/2481) with MSE=0.0740254
    Camera #3 projections: 65% inliers (1805/2782) with MSE=0.0876169
    Camera #4 projections: 62% inliers (2074/3372) with MSE=0.116189
    Camera #5 projections: 72% inliers (2322/3209) with MSE=0.171909
    Camera #6 projections: 77% inliers (2737/3574) with MSE=0.170881
    Camera #7 projections: 83% inliers (2724/3283) with MSE=0.150854
    Camera #8 projections: 88% inliers (2804/3198) with MSE=0.172289
    Camera #9 projections: 92% inliers (2447/2674) with MSE=0.176801
[       OK ] SFM.ReconstructNViews (36259 ms)
[----------] 1 test from SFM (36259 ms total)
[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (36259 ms total)
[  PASSED  ] 1 test.
The command "./build/test_sfm_ba" exited with 0.
</pre>

</p></details>