### PR TITLE
Task05 Vsevolod Tur CSC

### DIFF
--- a/src/phg/mvs/depth_maps/pm_depth_maps.cpp
+++ b/src/phg/mvs/depth_maps/pm_depth_maps.cpp
@@ -52,9 +52,9 @@ namespace phg {
     {
         double depth = pixel[2]; // на самом деле это не глубина, это координата по оси +Z (вдоль которой смотрит камера в ее локальной системе координат)
 
-        vector3d local_point; // TODO 102 пустите луч pixel из calibration а затем возьмите ан нем точку у которой по оси +Z координата=depth
+        vector3d local_point = calibration.unproject({pixel[0], pixel[1]}) * depth; // TODO 102 пустите луч pixel из calibration а затем возьмите ан нем точку у которой по оси +Z координата=depth
 
-        vector3d global_point; // TODO 103 переведите точку из локальной системы в глобальную
+        vector3d global_point = PtoWorld * homogenize(local_point); // TODO 103 переведите точку из локальной системы в глобальную
 
         return global_point;
     }
@@ -116,8 +116,9 @@ namespace phg {
                     n0 = normal_map.at<vector3f>(j, i);
 
                     // 2) случайной пертурбации текущей гипотезы (мутация и уточнение того что уже смогли найти)
-                    dp = r.nextf(d0 * 0.5f, d0 * 1.5); // TODO 104: сделайте так чтобы отклонение было тем меньше, чем номер итерации ближе к NITERATIONS, улучшило ли это результат?
-                    np = cv::normalize(n0 + randomNormalObservedFromCamera(cameras_RtoWorld[ref_cam], r) * 0.5); // TODO 105: сделайте так чтобы отклонение было тем меньше, чем номер итерации ближе к NITERATIONS, улучшило ли это результат?
+                    float d_iter = (1.0f - (float)(iter) / NITERATIONS) / 2.0f;
+                    dp = r.nextf(d0 * (1 - d_iter), d0 * (1 + d_iter)); // TODO 104: сделайте так чтобы отклонение было тем меньше, чем номер итерации ближе к NITERATIONS, улучшило ли это результат?
+                    np = cv::normalize(n0 + randomNormalObservedFromCamera(cameras_RtoWorld[ref_cam], r) * d_iter); // TODO 105: сделайте так чтобы отклонение было тем меньше, чем номер итерации ближе к NITERATIONS, улучшило ли это результат?
 
                     dp = std::max(ref_depth_min, std::min(ref_depth_max, dp));
 
@@ -126,6 +127,8 @@ namespace phg {
                     //  - r.nextf(...)
                     //  - ref_depth_min, ref_depth_max
                     //  - randomNormalObservedFromCamera - поможет создать нормаль которая гарантированно смотрит на нас 
+                    dr = r.nextf(ref_depth_min, ref_depth_max);
+                    nr = cv::normalize(randomNormalObservedFromCamera(cameras_RtoWorld[ref_cam], r));
                 }
 
                 float    best_depth  = d0;
@@ -260,6 +263,15 @@ namespace phg {
                     // TODO 203 - логика про "берем 8 лучших по их личной оценке - по их личному cost" и только их примеряем уже на себя для рассчета cost в нашей точке
                     // TODO 301 - сделайте вместо наивного переноса depth+normal в наш пиксель - логику про "пересекли луч из нашего пикселя с плоскостью которую задает донор-сосед" и оценку cost в нашей точке тогда можно провести для более релевантной точки-пересечения 
 
+                    std::vector<short> best_index(hypos_depth.size());
+                    for (int i = 0; i < hypos_depth.size(); i++)
+                        best_index[i] = i;
+
+                    std::sort(best_index.begin(), best_index.end(),
+                        [&hypos_cost] (const short &a, const short &b) -> bool {
+                            return hypos_cost[b] > hypos_cost[a];
+                    });
+
                     float    best_depth  = depth_map.at<float>(j, i);
                     vector3f best_normal = normal_map.at<vector3f>(j, i);
                     float    best_cost   = cost_map.at<float>(j, i);
@@ -267,8 +279,10 @@ namespace phg {
                         best_cost = NO_COST;
                     }
     
-                    for (size_t hi = 0; hi < hypos_depth.size(); ++hi) {
+                    size_t hi_num = std::min(hypos_depth.size(), (size_t)(8));
+                    for (size_t hi_ptr = 0; hi_ptr < hi_num; ++hi_ptr) {
                         // эту гипотезу мы сейчас рассматриваем как очередного кандидата
+                        size_t  hi = best_index[hi_ptr];
                         float    d = hypos_depth[hi];
                         vector3f n = hypos_normal[hi];
     
@@ -330,7 +344,7 @@ namespace phg {
                 patch0.push_back(cameras_imgs_grey[ref_cam].at<unsigned char>(nj, ni) / 255.0f);
 
                 vector3d point_on_ray  = unproject(vector3d(ni + 0.5, nj + 0.5, 1.0), calibration, cameras_PtoWorld[ref_cam]);
-                vector3d camera_center = unproject(vector3d(ni + 0.5, nj + 0.5, 0.0), calibration, cameras_PtoWorld[ref_cam]); // TODO 204: это немного неестественный способ, можно поправить его на более явный вариант, например хранить центр камер в поле cameras_O
+                vector3d camera_center = cameras_PtoWorld[ref_cam] * vector4d(0.0, 0.0, 0.0, 1.0); // TODO 204: это немного неестественный способ, можно поправить его на более явный вариант, например хранить центр камер в поле cameras_O
 
                 vector3d ray_dir = cv::normalize(point_on_ray - camera_center);
                 vector3d ray_org = camera_center;
@@ -352,8 +366,19 @@ namespace phg {
                 ptrdiff_t v = y;
 
                 // TODO 108: добавьте проверку "попали ли мы в камеру номер neighb_cam?" если не попали - возвращаем NO_COST
+                if (!(0 < u && u < width) || !(0 < v && v < height)) {
+                    return NO_COST;
+                }
 
-                float intensity = cameras_imgs_grey[neighb_cam].at<unsigned char>(v, u) / 255.0f;
+                double dx = x - (int)(x);
+                double dy = y - (int)(y);
+
+                double d00 = cameras_imgs_grey[neighb_cam].at<unsigned char>(v, u)         * (1 - dx) * (1 - dy);
+                double d01 = cameras_imgs_grey[neighb_cam].at<unsigned char>(v, u + 1)     * dx       * (1 - dy);
+                double d10 = cameras_imgs_grey[neighb_cam].at<unsigned char>(v + 1, u)     * (1 - dx) * dy;
+                double d11 = cameras_imgs_grey[neighb_cam].at<unsigned char>(v + 1, u + 1) * dx       * dy;
+
+                float intensity = (d00 + d01 + d10 + d11) / 255.0f;
                 patch1.push_back(intensity);
             }
         }
@@ -376,6 +401,20 @@ namespace phg {
         mean1 /= n;
         // ...
         float zncc = 0.0f;
+        float d00_sum = 0.0f;
+        float d11_sum = 0.0f;
+
+        for (size_t k = 0; k < n; ++k) {
+            float d0 = patch0[k] - mean0;
+            float d1 = patch1[k] - mean1;
+            zncc += d0 * d1;
+            d00_sum += d0 * d0;
+            d11_sum += d1 * d1;
+        }
+
+        if (std::abs(zncc) > 1e-7) {
+            zncc /= std::sqrt(d00_sum * d11_sum);
+        }
 
         // ZNCC в диапазоне [-1; 1], 1: идеальное совпадение, -1: ничего общего
         rassert(zncc == zncc, 23141241210380); // проверяем что не nan
@@ -399,13 +438,20 @@ namespace phg {
 
         float best_cost = costs[0];
 
-        float cost_sum = best_cost;
-        float cost_w = 1.0f;
+        float cost_sum = 0.0f;
+        float cost_w = 0.0f;
 
         // TODO 110 реализуйте какое-то "усреднение cost-ов по всем соседям", с ограничением что участвуют только COSTS_BEST_K_LIMIT лучших
         // TODO 111 добавьте к этому усреднению еще одно ограничение: если cost больше чем best_cost*COSTS_K_RATIO - то такой cost подозрительно плохой и мы его не хотим учитывать (вероятно occlusion)
         // TODO 112 а что если в пикселе occlusion, но best_cost - большой и поэтому отсечение по best_cost*COSTS_K_RATIO не срабатывает? можно ли это отсечение как-то выправить для такого случая?
         // TODO 207 а что если добавить какой-нибудь бонус в случае если больше чем Х камер засчиталось? улучшается/ухудшается ли от этого что-то на herzjezu25? а при большем числе фотографий
+        size_t n = std::min(costs.size(), (size_t)(COSTS_BEST_K_LIMIT));
+        for (size_t i = 1; i < n; ++i) {
+            if (costs[i] < best_cost * COSTS_K_RATIO) {
+                cost_sum += costs[i];
+                cost_w++;
+            }
+        }
 
         float avg_cost = cost_sum / cost_w;
         return avg_cost;


### PR DESCRIPTION
Перечислите идеи и коротко обозначьте мысли которые у вас возникали по мере выполнения задания (так же комментарии и мысли прямо в коде пишите по мере выполнения задания)

Приложите скриншоты облаков точек которые вам больше всего понравились, показывают какой-то интересный/неожиданный результат какого-то эксперимента/что-то еще.

![Screenshot from 2021-04-07 21-20-02](https://user-images.githubusercontent.com/60890623/113915235-32c5de80-97e7-11eb-9cf7-2705d7c4125a.png)

<details><summary>Local</summary><p>

<pre>
$ ./test_depth_maps_pm 
Running main() from /home/tur/PhotogrammetryTasks2021-task05/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DepthMap
[ RUN      ] DepthMap.FirstStereoPair
loading 25 images...
resolution: 384x256
herzjesu25 dataset loaded in 4.17856 s
tie points cloud with cameras exported to: data/debug/test_depth_maps_pm/FirstStereoPair/0_tie_points_and_cameras25.ply
Iteration #0/5: refinement...
refinement done in 14.4059 s: 73% pixels with 0.395262 avg cost, 6% pixels with good 0.1283 avg cost
Iteration #1/5: propagation...
propagation done in 29.4521 s: 93% pixels with 0.228398 avg cost, 39% pixels with good 0.10775 avg cost
Iteration #1/5: refinement...
refinement done in 34.5327 s: 93% pixels with 0.213243 avg cost, 43% pixels with good 0.105902 avg cost
Iteration #2/5: propagation...
propagation done in 34.9531 s: 94% pixels with 0.129822 avg cost, 70% pixels with good 0.0789503 avg cost
Iteration #2/5: refinement...
refinement done in 38.2616 s: 94% pixels with 0.12576 avg cost, 71% pixels with good 0.0775793 avg cost
Iteration #3/5: propagation...
propagation done in 34.5081 s: 94% pixels with 0.0933763 avg cost, 80% pixels with good 0.061159 avg cost
Iteration #3/5: refinement...
refinement done in 35.0355 s: 94% pixels with 0.0916217 avg cost, 80% pixels with good 0.0605523 avg cost
Iteration #4/5: propagation...
propagation done in 32.3243 s: 94% pixels with 0.0785771 avg cost, 83% pixels with good 0.0538418 avg cost
Iteration #4/5: refinement...
refinement done in 34.0594 s: 94% pixels with 0.0774883 avg cost, 83% pixels with good 0.0534738 avg cost
Iteration #5/5: propagation...
propagation done in 32.2255 s: 94% pixels with 0.0712651 avg cost, 85% pixels with good 0.0506965 avg cost
Iteration #5/5: refinement...
refinement done in 37.3808 s: 94% pixels with 0.0710769 avg cost, 85% pixels with good 0.0506517 avg cost
[       OK ] DepthMap.FirstStereoPair (361992 ms)
[----------] 1 test from DepthMap (361992 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (361992 ms total)
[  PASSED  ] 1 test.
</pre>

</p></details>
