### PR TITLE
Task06 Kirill Pilyugin

### DIFF
--- a/src/phg/mvs/model_min_cut/min_cut_cgal_structs.cpp
+++ b/src/phg/mvs/model_min_cut/min_cut_cgal_structs.cpp
@@ -22,6 +22,12 @@ vertex_info_t::vertex_info_t(unsigned int camera_id, const cv::Vec3b &color, dou
 
 void vertex_info_t::merge(const vertex_info_t &that)
 {
+    double w1 = camera_ids.size();
+    double w2 = that.camera_ids.size();
+    for (int i = 0; i < 3; ++i) {
+        color[i] = (w1 * color[i] + w2 * that.color[i]) / (w1 + w2);
+    }
+
     for (int i = 1; i < camera_ids.size(); ++i) {
         rassert(camera_ids[i - 1] < camera_ids[i], 23781274121024);
     }

--- a/src/phg/mvs/model_min_cut/min_cut_cgal_structs.cpp
+++ b/src/phg/mvs/model_min_cut/min_cut_cgal_structs.cpp
@@ -13,7 +13,9 @@ cgal_point_t to_cgal_point(vector3d p)
     return cgal_point_t(p[0], p[1], p[2]);
 }
 
-vertex_info_t::vertex_info_t(unsigned int camera_id, const cv::Vec3b &color) : color(color)
+vertex_info_t::vertex_info_t(unsigned int camera_id, const cv::Vec3b &color, double radius) :
+    color(color),
+    radius(radius)
 {
     camera_ids.push_back(camera_id);
 }

--- a/src/phg/mvs/model_min_cut/min_cut_cgal_structs.h
+++ b/src/phg/mvs/model_min_cut/min_cut_cgal_structs.h
@@ -11,12 +11,13 @@
 struct vertex_info_t {
     std::vector<unsigned int> camera_ids;
     cv::Vec3b                 color;
-    size_t                    vertex_on_surface_id;
+    size_t                    vertex_on_surface_id = 0;
+    double                    radius;
 
     vertex_info_t() : color(0, 0, 255) // red color, BGR convention (OpenCV compatible)
     {}
 
-    vertex_info_t(unsigned int camera_id, const cv::Vec3b &color);
+    vertex_info_t(unsigned int camera_id, const cv::Vec3b &color, double radius);
 
     void merge(const vertex_info_t &that);
 };

--- a/src/phg/mvs/model_min_cut/min_cut_defines.h
+++ b/src/phg/mvs/model_min_cut/min_cut_defines.h
@@ -5,3 +5,7 @@
 #define LAMBDA_SOURCE                   1000000.0
 
 #define SOFT_VISIBILITY_SIGMA           0.001
+
+#define WEAK_SUPPORT_ENABLED            1
+#define WEAK_SUPPORT_ALPHA_RATIO        0.5
+#define WEAK_SUPPORT_BETA_THRESHOLD     1000.0

--- a/src/phg/mvs/model_min_cut/min_cut_defines.h
+++ b/src/phg/mvs/model_min_cut/min_cut_defines.h
@@ -1,4 +1,5 @@
-#define MERGE_THRESHOLD_RADIUS_KOEF     0.1
+#define MERGE_THRESHOLD_RADIUS_KOEF     0.3
 
 #define LAMBDA_OUT                      1.0
 #define LAMBDA_IN                       1.0
+#define LAMBDA_SOURCE                   1000000.0

--- a/src/phg/mvs/model_min_cut/min_cut_defines.h
+++ b/src/phg/mvs/model_min_cut/min_cut_defines.h
@@ -4,7 +4,7 @@
 #define LAMBDA_IN                       1.0
 #define LAMBDA_SOURCE                   1000000.0
 
-#define SOFT_VISIBILITY_SIGMA           0.001
+#define SOFT_VISIBILITY_SIGMA           5
 
 #define WEAK_SUPPORT_ENABLED            1
 #define WEAK_SUPPORT_ALPHA_RATIO        0.5

--- a/src/phg/mvs/model_min_cut/min_cut_defines.h
+++ b/src/phg/mvs/model_min_cut/min_cut_defines.h
@@ -1,5 +1,7 @@
-#define MERGE_THRESHOLD_RADIUS_KOEF     0.3
+#define MERGE_THRESHOLD_RADIUS_KOEF     0.8
 
 #define LAMBDA_OUT                      1.0
 #define LAMBDA_IN                       1.0
 #define LAMBDA_SOURCE                   1000000.0
+
+#define SOFT_VISIBILITY_SIGMA           0.001

--- a/src/phg/mvs/model_min_cut/min_cut_model_builder.cpp
+++ b/src/phg/mvs/model_min_cut/min_cut_model_builder.cpp
@@ -468,7 +468,7 @@ void MinCutModelBuilder::buildMesh(std::vector<cv::Vec3i> &mesh_faces, std::vect
                 // увеличиваем пропускную способность на треугольнике-ребре (в направлении от камеры к точке)
                 // 3001 сделайте пропускные способности на ребрах не единичными а затухающими тем сильнее чем ближе к поверхности
                 double d2 = distance_from_surface * distance_from_surface;
-                double sigma = SOFT_VISIBILITY_SIGMA; //point_radius;
+                double sigma = SOFT_VISIBILITY_SIGMA * point_radius;
                 double soft_factor = 1 - exp(-d2 / (2 * sigma * sigma));
                 double capacity = LAMBDA_OUT * soft_factor;
                 next_cell->info().facets_capacities[next_cell_facet_subindex] += capacity;

--- a/tests/test_mesh_min_cut.cpp
+++ b/tests/test_mesh_min_cut.cpp
@@ -95,7 +95,7 @@ std::vector<cv::Mat> loadDepthMaps(const std::string &datasetDir, int downscale,
 }
 
 TEST (test_mesh_min_cut, DepthMapsToPointClouds) {
-    // TODO 1001: запустите test_mesh_min_cut/DepthMapsToPointClouds и убедитесь что облака точек построенные по картам глубины выглядят правдоподобно
+    // 1001: запустите test_mesh_min_cut/DepthMapsToPointClouds и убедитесь что облака точек построенные по картам глубины выглядят правдоподобно
     // Этот тест просто проверяет что логика считывания карт глубины и их интерпретация - работают
     // Для этого вам надо скачать карты глубины по ссылкам выше (см. "Datasets")
     // Затем запустить этот тест, в частности он преобразует карты глубины в облака точек, взгляните на них в папке: data/debug/test_mesh_min_cut/DepthMapsToPointClouds
@@ -165,7 +165,7 @@ TEST (test_mesh_min_cut, FromSingleDepthMap) {
 }
 
 TEST (test_mesh_min_cut, FromAllDepthMaps) {
-    // TODO 1002: запустите test_mesh_min_cut/FromAllDepthMaps и убедитесь что полигональные модели построенные по картам глубины выглядят правдоподобно
+    // 1002: запустите test_mesh_min_cut/FromAllDepthMaps и убедитесь что полигональные модели построенные по картам глубины выглядят правдоподобно
     // Этот тест строит модель на базе всех карт глубин (с учетом опционального ограничения CAMERAS_LIMIT)
     // Результаты см. в папке data/debug/test_mesh_min_cut/FromAllDepthMaps
     Dataset dataset = loadDataset(DATASET_DIR, DATASET_DOWNSCALE);


### PR DESCRIPTION
Лучшие результаты примерно такие получились

<img width="400" alt="Screenshot 2021-04-20 at 12 18 55" src="https://user-images.githubusercontent.com/6966433/115389382-4efd4e80-a1dd-11eb-938c-a312446bc447.png">
<img width="400" alt="Screenshot 2021-04-20 at 12 25 19" src="https://user-images.githubusercontent.com/6966433/115389397-53c20280-a1dd-11eb-9300-7199dc93c003.png">


- [x] **TODO 1001** запустите test_mesh_min_cut/DepthMapsToPointClouds и убедитесь что облака точек построенные по картам глубины выглядят правдоподобно
- [x] **TODO 1002** запустите test_mesh_min_cut/FromAllDepthMaps и убедитесь что полигональные модели построенные по картам глубины выглядят правдоподобно и например для DATASET_DIR=saharov32, DATASET_DOWNSCALE=4, CAMERAS_LIMIT=5 выглядит похоже на это:
- [x] **TODO 2001** appendToTriangulation(): реализуйте нормальную проверку объединять ли точку с уже добавленной ранее (с учетом r и MERGE_THRESHOLD_RADIUS_KOEF)
- [x] **TODO 2002** добавьте проверку - не опирается ли треугольник на одну из фиктивных вершин (лежащих на гранях вспомогательного bounding box), можете для этого использовать bb_min и bb_max, или добавьте явный флаг в каждую вершину
- [x] **TODO 2003** некоторые треугольники выглядят темными в результирующей модели, проблема уходит если выключить в MeshLab освещение (кнопка желтой лампочка - Light on/off) которое учитывает нормаль, которая строится с учетом порядка вершин треугольника (по часовой стрелке или против)
- [x] **TODO 2004** подумайте и напишите тут какие вершины бывают без камер вообще? почему мы их пропускаем? что и почему случится если убрать это пропускание?

Вершины без точек - это фиктивные вершины на сторонах bounding box-a, которые мы добавляли чтобы не работать с бесконечными внешними тетраэдрами. Если убрать пропускание - будем обрабатывать бесконечные клетки которые не имеют отношения к модели.

- [x] **TODO 2005** изменится ли что-то если сильно увеличить пропускные способности ребер от истока? (т.е. сделать пропускную способность из истока равной бесконечности?)

Про ребра от истока мы знаем что они точно находятся снаружи поверхности, поставив бесконечную пропускную способность на эти ребра можно гарантировать что разрез там точно не пройдет.

- [x] **TODO 3001** сделайте пропускные способности на ребрах не единичными а затухающими тем сильнее чем ближе к поверхности

- [x] **TODO 3002** сделайте соединение со стоком в ячейке не сразу за вершиной, а на небольшом углублении (пропорционально размеру точки)

- [x] **TODO 3500** Weak support: реализуйте идею из [jancosek2011 - Multi-View Reconstruction Preserving Weakly-Supported Surfaces](https://compsciclub.ru/attachments/classes/file_XyLpDjLx/jancosek2011.pdf)

Эти три модификации не давали значительных улучшений на памятнике, хотя интуитивно кажется что должны бы - хотя бы первые две. 

- [x] **TODO 4001** подвиньте вершины в среднюю координату среди всех точек которые в ней зачлись

Это заметно помогает убрать мелкие шумы на поверхности

- [x] **TODO 4002** поэкспериментируйте со значением MERGE_THRESHOLD_RADIUS_KOEF, есть ли интересности? какое значение вы бы предложили использовать в условной финальной версии?

Увеличение этого порога позволяет немного сгладить модель в местах, где облако точек очень плотное. При этом если его поставить слишком большим, может начать уменьшаться детальность модели. Для памятника у меня получилось оптимальное значение в районе 0.5-0.8. 

<img width="400" alt="Screenshot 2021-04-20 at 12 11 39" src="https://user-images.githubusercontent.com/6966433/115391157-705f3a00-a1df-11eb-9108-a7feeffa426e.png">
<img width="400" alt="Screenshot 2021-04-20 at 12 09 33" src="https://user-images.githubusercontent.com/6966433/115391168-72c19400-a1df-11eb-83a0-00f7f7649e4f.png">

- [x] **TODO 4003** добавьте усреднение цветов среди всех склеившихся вершин, приложите скриншот с/без усреднения

Без: <img width="300" alt="Screenshot 2021-04-19 at 13 05 02" src="https://user-images.githubusercontent.com/6966433/115391616-f7141700-a1df-11eb-9b24-c64e56f53838.png">
С усреднением цветов: <img width="300" alt="Screenshot 2021-04-19 at 13 04 54" src="https://user-images.githubusercontent.com/6966433/115391650-fc716180-a1df-11eb-87f8-2c919a3ad52f.png">

