### PR TITLE
Task06 Stepan Trofimov CSClub

### DIFF
--- a/src/phg/mvs/model_min_cut/min_cut_cgal_structs.cpp
+++ b/src/phg/mvs/model_min_cut/min_cut_cgal_structs.cpp
@@ -13,7 +13,9 @@ cgal_point_t to_cgal_point(vector3d p)
     return cgal_point_t(p[0], p[1], p[2]);
 }
 
-vertex_info_t::vertex_info_t(unsigned int camera_id, const cv::Vec3b &color) : color(color)
+vertex_info_t::vertex_info_t(unsigned int camera_id, const cv::Vec3b &color, const double &radius) :
+    color(color),
+    radius(radius)
 {
     camera_ids.push_back(camera_id);
 }

--- a/src/phg/mvs/model_min_cut/min_cut_cgal_structs.h
+++ b/src/phg/mvs/model_min_cut/min_cut_cgal_structs.h
@@ -12,11 +12,12 @@ struct vertex_info_t {
     std::vector<unsigned int> camera_ids;
     cv::Vec3b                 color;
     size_t                    vertex_on_surface_id;
+    double                    radius;
 
     vertex_info_t() : color(0, 0, 255) // red color, BGR convention (OpenCV compatible)
     {}
 
-    vertex_info_t(unsigned int camera_id, const cv::Vec3b &color);
+    vertex_info_t(unsigned int camera_id, const cv::Vec3b &color, const double &radius);
 
     void merge(const vertex_info_t &that);
 };

--- a/tests/test_mesh_min_cut.cpp
+++ b/tests/test_mesh_min_cut.cpp
@@ -95,7 +95,6 @@ std::vector<cv::Mat> loadDepthMaps(const std::string &datasetDir, int downscale,
 }
 
 TEST (test_mesh_min_cut, DepthMapsToPointClouds) {
-    // TODO 1001: запустите test_mesh_min_cut/DepthMapsToPointClouds и убедитесь что облака точек построенные по картам глубины выглядят правдоподобно
     // Этот тест просто проверяет что логика считывания карт глубины и их интерпретация - работают
     // Для этого вам надо скачать карты глубины по ссылкам выше (см. "Datasets")
     // Затем запустить этот тест, в частности он преобразует карты глубины в облака точек, взгляните на них в папке: data/debug/test_mesh_min_cut/DepthMapsToPointClouds
@@ -165,7 +164,6 @@ TEST (test_mesh_min_cut, FromSingleDepthMap) {
 }
 
 TEST (test_mesh_min_cut, FromAllDepthMaps) {
-    // TODO 1002: запустите test_mesh_min_cut/FromAllDepthMaps и убедитесь что полигональные модели построенные по картам глубины выглядят правдоподобно
     // Этот тест строит модель на базе всех карт глубин (с учетом опционального ограничения CAMERAS_LIMIT)
     // Результаты см. в папке data/debug/test_mesh_min_cut/FromAllDepthMaps
     Dataset dataset = loadDataset(DATASET_DIR, DATASET_DOWNSCALE);


### PR DESCRIPTION
- [x] **TODO 1001** запустите test_mesh_min_cut/DepthMapsToPointClouds и убедитесь что облака точек построенные по картам глубины выглядят правдоподобно

![image](https://user-images.githubusercontent.com/64556766/115431342-dbc00080-a20d-11eb-8948-53398de9bee9.png)

- [x] **TODO 1002** запустите test_mesh_min_cut/FromAllDepthMaps и убедитесь что полигональные модели построенные по картам глубины выглядят правдоподобно и например для DATASET_DIR=saharov32, DATASET_DOWNSCALE=4, CAMERAS_LIMIT=5 выглядит похоже на это:

![image](https://user-images.githubusercontent.com/64556766/115432861-8ab10c00-a20f-11eb-891b-e965afd33fae.png)

- [x] **TODO 2001** appendToTriangulation(): реализуйте нормальную проверку объединять ли точку с уже добавленной ранее (с учетом r и MERGE_THRESHOLD_RADIUS_KOEF)

- [x] **TODO 2002** добавьте проверку - не опирается ли треугольник на одну из фиктивных вершин (лежащих на гранях вспомогательного bounding box), можете для этого использовать bb_min и bb_max, или добавьте явный флаг в каждую вершину

- [x] **TODO 2003** некоторые треугольники выглядят темными в результирующей модели, проблема уходит если выключить в MeshLab освещение (кнопка желтой лампочка - Light on/off) которое учитывает нормаль, которая строится с учетом порядка вершин треугольника (по часовой стрелке или против)

- [x] **TODO 2004** подумайте и напишите тут какие вершины бывают без камер вообще? почему мы их пропускаем? что и почему случится если убрать это пропускание?

Вершины без камер - фиктивные. Если не пропускать - будем обрабатывать бесконечные треугольники. 

- [x] **TODO 2005** изменится ли что-то если сильно увеличить пропускные способности ребер от истока? (т.е. сделать пропускную способность из истока равной бесконечности?)

Будем откидывать разрез через эти ребра.

- [x] **TODO 3001** сделайте пропускные способности на ребрах не единичными а затухающими тем сильнее чем ближе к поверхности

- [x] **TODO 3002** сделайте соединение со стоком в ячейке не сразу за вершиной, а на небольшом углублении (пропорционально размеру точки)

- [ ] **TODO 3500** Weak support: реализуйте идею из [jancosek2011 - Multi-View Reconstruction Preserving Weakly-Supported Surfaces](https://compsciclub.ru/attachments/classes/file_XyLpDjLx/jancosek2011.pdf)

- [x] **TODO 4001** подвиньте вершины в среднюю координату среди всех точек которые в ней зачлись

- [x] **TODO 4002** поэкспериментируйте со значением MERGE_THRESHOLD_RADIUS_KOEF, есть ли интересности? какое значение вы бы предложили использовать в условной финальной версии?

При значинии MERGE_THRESHOLD_RADIUS_KOEF = 0.5 достаточно хорошо сглаживаются густые облака точек. 

- [x] **TODO 4003** добавьте усреднение цветов среди всех склеившихся вершин, приложите скриншот с/без усреднения

С усреднением:
![image](https://user-images.githubusercontent.com/64556766/116243486-a9635580-a76f-11eb-8041-0d6893a36d2d.png)

Без усреднения:
![image](https://user-images.githubusercontent.com/64556766/116248057-27296000-a774-11eb-8eb4-96d588abb923.png)

- [ ] **TODO 5001** как в целом можно ускорить реализацию? есть ли идеи? попробуйте это сделать (и запишите какого ускорения получилось добиться, а так же изменился ли результат)

- [ ] **TODO 5002** а не рапараллелить ли? если будете распараллеливать - убедитесь что вы заменили triangulation.incident_cells() на triangulation.incident_cells_threadsafe()

- [ ] **TODO 5003** не слишком ли часто вызывается triangulation.locate()? может оно тормозит? (поиск ячейки содержащей заданную точку)

- [ ] **TODO 5004** CGAL::do_intersect() проверяет луч и треугольник на пересечение абсолютно точно, и это надежно, но медленно. А что если мы грубо будем проверять пересечения (самописным простым кодом на float-ах)? А когда пересечение не факт что произошло - ну что же, пусть этому лучу не повезло, будем надеяться это не сильно изменит результат? Попробуйте и сравните скорость и результат.
