### PR TITLE
Task06 Anna Leonova CSC 

### DIFF
--- a/src/phg/mvs/model_min_cut/min_cut_cgal_structs.cpp
+++ b/src/phg/mvs/model_min_cut/min_cut_cgal_structs.cpp
@@ -13,7 +13,7 @@ cgal_point_t to_cgal_point(vector3d p)
     return cgal_point_t(p[0], p[1], p[2]);
 }
 
-vertex_info_t::vertex_info_t(unsigned int camera_id, const cv::Vec3b &color) : color(color)
+vertex_info_t::vertex_info_t(unsigned int camera_id, const cv::Vec3b &color, double r) : color(color), radius(r)
 {
     camera_ids.push_back(camera_id);
 }

--- a/src/phg/mvs/model_min_cut/min_cut_cgal_structs.h
+++ b/src/phg/mvs/model_min_cut/min_cut_cgal_structs.h
@@ -12,11 +12,11 @@ struct vertex_info_t {
     std::vector<unsigned int> camera_ids;
     cv::Vec3b                 color;
     size_t                    vertex_on_surface_id;
-
+    double radius;
     vertex_info_t() : color(0, 0, 255) // red color, BGR convention (OpenCV compatible)
     {}
 
-    vertex_info_t(unsigned int camera_id, const cv::Vec3b &color);
+    vertex_info_t(unsigned int camera_id, const cv::Vec3b &color, double r);
 
     void merge(const vertex_info_t &that);
 };

--- a/src/phg/mvs/model_min_cut/min_cut_defines.h
+++ b/src/phg/mvs/model_min_cut/min_cut_defines.h
@@ -1,4 +1,7 @@
 #define MERGE_THRESHOLD_RADIUS_KOEF     0.1
 
+#define COLOR_MEAN                      true
+#define DEPTH_COEF                      3
+
 #define LAMBDA_OUT                      1.0
 #define LAMBDA_IN                       1.0

--- a/src/phg/mvs/model_min_cut/min_cut_model_builder.cpp
+++ b/src/phg/mvs/model_min_cut/min_cut_model_builder.cpp
@@ -519,8 +519,8 @@ void MinCutModelBuilder::buildMesh(std::vector<cv::Vec3i> &mesh_faces, std::vect
 
             for (int v_index = 1; v_index <= 3; ++v_index) {
                 auto vi = ci->vertex(indexes[i * 3 + v_index - 1]);
-                for (int i = 0; i < 3; i++) {
-                    if (std::abs(vi->point()[i] - bb_min[i]) < 10e-4 || std::abs(vi->point()[i] - bb_min[i]) < 10e-4) {
+                for (int j = 0; j < 3; j++) {
+                    if (std::abs(vi->point()[j] - bb_min[j]) < 10e-4 || std::abs(vi->point()[j] - bb_max[j]) < 10e-4) {
                         fake = true;
                     }
                 }

--- a/tests/test_mesh_min_cut.cpp
+++ b/tests/test_mesh_min_cut.cpp
@@ -95,7 +95,7 @@ std::vector<cv::Mat> loadDepthMaps(const std::string &datasetDir, int downscale,
 }
 
 TEST (test_mesh_min_cut, DepthMapsToPointClouds) {
-    // TODO 1001: запустите test_mesh_min_cut/DepthMapsToPointClouds и убедитесь что облака точек построенные по картам глубины выглядят правдоподобно
+    // TODO 1001 - done: запустите test_mesh_min_cut/DepthMapsToPointClouds и убедитесь что облака точек построенные по картам глубины выглядят правдоподобно
     // Этот тест просто проверяет что логика считывания карт глубины и их интерпретация - работают
     // Для этого вам надо скачать карты глубины по ссылкам выше (см. "Datasets")
     // Затем запустить этот тест, в частности он преобразует карты глубины в облака точек, взгляните на них в папке: data/debug/test_mesh_min_cut/DepthMapsToPointClouds
@@ -165,7 +165,7 @@ TEST (test_mesh_min_cut, FromSingleDepthMap) {
 }
 
 TEST (test_mesh_min_cut, FromAllDepthMaps) {
-    // TODO 1002: запустите test_mesh_min_cut/FromAllDepthMaps и убедитесь что полигональные модели построенные по картам глубины выглядят правдоподобно
+    // TODO 1002 - done: запустите test_mesh_min_cut/FromAllDepthMaps и убедитесь что полигональные модели построенные по картам глубины выглядят правдоподобно
     // Этот тест строит модель на базе всех карт глубин (с учетом опционального ограничения CAMERAS_LIMIT)
     // Результаты см. в папке data/debug/test_mesh_min_cut/FromAllDepthMaps
     Dataset dataset = loadDataset(DATASET_DIR, DATASET_DOWNSCALE);


### PR DESCRIPTION
## Задачу буду еще доделывать и обновлю Pull Request

- [x] **TODO 1001** запустите test_mesh_min_cut/DepthMapsToPointClouds и убедитесь что облака точек построенные по картам глубины выглядят правдоподобно

- [x] **TODO 1002** запустите test_mesh_min_cut/FromAllDepthMaps и убедитесь что полигональные модели построенные по картам глубины выглядят правдоподобно и например для DATASET_DIR=saharov32, DATASET_DOWNSCALE=4, CAMERAS_LIMIT=5 выглядит похоже на это:

![leonova1](https://user-images.githubusercontent.com/13620271/115443328-c8b42d00-a21b-11eb-887a-6bb71a7a9615.jpg)

- [x] **TODO 2001** appendToTriangulation(): реализуйте нормальную проверку объединять ли точку с уже добавленной ранее (с учетом r и MERGE_THRESHOLD_RADIUS_KOEF)

- [x] **TODO 2002** добавьте проверку - не опирается ли треугольник на одну из фиктивных вершин (лежащих на гранях вспомогательного bounding box), можете для этого использовать bb_min и bb_max, или добавьте явный флаг в каждую вершину

- [x] **TODO 2003** некоторые треугольники выглядят темными в результирующей модели, проблема уходит если выключить в MeshLab освещение (кнопка желтой лампочка - Light on/off) которое учитывает нормаль, которая строится с учетом порядка вершин треугольника (по часовой стрелке или против)

- [x] **TODO 2004** подумайте и напишите тут какие вершины бывают без камер вообще? почему мы их пропускаем? что и почему случится если убрать это пропускание?

- Мы делаем проверку, чтобы не работать с бесконечными треугольниками.

- [x] **TODO 2005** изменится ли что-то если сильно увеличить пропускные способности ребер от истока? (т.е. сделать пропускную способность из истока равной бесконечности?)

- Это будет влиять на поиск минимального разреза. И тогда найденный разрез не будет проходить через эти ребра.

- [x] **TODO 3001** сделайте пропускные способности на ребрах не единичными а затухающими тем сильнее чем ближе к поверхности

- [x] **TODO 3002** сделайте соединение со стоком в ячейке не сразу за вершиной, а на небольшом углублении (пропорционально размеру точки)

- [ ] **TODO 3500** Weak support: реализуйте идею из [jancosek2011 - Multi-View Reconstruction Preserving Weakly-Supported Surfaces](https://compsciclub.ru/attachments/classes/file_XyLpDjLx/jancosek2011.pdf)

- [x] **TODO 4001** подвиньте вершины в среднюю координату среди всех точек которые в ней зачлись

- [x] **TODO 4002** поэкспериментируйте со значением MERGE_THRESHOLD_RADIUS_KOEF, есть ли интересности? какое значение вы бы предложили использовать в условной финальной версии?

- При увеличении значения параметра MERGE_THRESHOLD_RADIUS_KOEF картинка становится более размыленной, а при уменьшении густые облака точек начинают выглядет слишком "острыми". Я бы предложила параметр равный 0.7

- [x] **TODO 4003** добавьте усреднение цветов среди всех склеившихся вершин, приложите скриншот с/без усреднения

С усреднением цветов:
![leonova-with-mean](https://user-images.githubusercontent.com/13620271/116282402-6024fd00-a793-11eb-8c5b-16039ebd88df.png)

Без усреднения цвета:
![leonova-without-mean](https://user-images.githubusercontent.com/13620271/116282510-89458d80-a793-11eb-95da-d1188e93cda1.png)

- [ ] **TODO 5001** как в целом можно ускорить реализацию? есть ли идеи? попробуйте это сделать (и запишите какого ускорения получилось добиться, а так же изменился ли результат)

- [ ] **TODO 5002** а не рапараллелить ли? если будете распараллеливать - убедитесь что вы заменили triangulation.incident_cells() на triangulation.incident_cells_threadsafe()

- [ ] **TODO 5003** не слишком ли часто вызывается triangulation.locate()? может оно тормозит? (поиск ячейки содержащей заданную точку)

- [ ] **TODO 5004** CGAL::do_intersect() проверяет луч и треугольник на пересечение абсолютно точно, и это надежно, но медленно. А что если мы грубо будем проверять пересечения (самописным простым кодом на float-ах)? А когда пересечение не факт что произошло - ну что же, пусть этому лучу не повезло, будем надеяться это не сильно изменит результат? Попробуйте и сравните скорость и результат.
